### PR TITLE
Add Excel streaming export library with Azure Blob upload

### DIFF
--- a/DataToExcel.Test/Application/ExportExcelTests.cs
+++ b/DataToExcel.Test/Application/ExportExcelTests.cs
@@ -1,0 +1,67 @@
+using System.Data;
+using DataToExcel.Application;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel.Models;
+using DataToExcel.Repositories;
+using DataToExcel.Services;
+using DataToExcel.Wrappers.Interfaces;
+using Moq;
+using Xunit;
+
+namespace DataToExcel.Test.Application;
+
+public class ExportExcelTests
+{
+    [Fact]
+    public async Task GivenValidRecordsWhenExecuteAsyncThenBlobShouldBeUploaded()
+    {
+        // Given
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+        var options = new ExcelExportOptions { SheetName = "Names" };
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var repo = new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5));
+        var useCase = new ExportExcel(
+            new ExcelExportService(new ExcelStyleProvider()),
+            new FileNamingService(),
+            repo,
+            new ExcelExportRegistrationOptions { ConnectionString = "UseDevelopmentStorage=true", ContainerName = "test" });
+
+        // When
+        var result = await useCase.ExecuteAsync(records, columns, "Report", options);
+
+        // Then
+        blobMock.Verify(
+            b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.NotNull(result);
+        Assert.EndsWith(".xlsx", result.BlobName);
+    }
+}

--- a/DataToExcel.Test/Application/ExportExcelTests.cs
+++ b/DataToExcel.Test/Application/ExportExcelTests.cs
@@ -51,8 +51,7 @@ public class ExportExcelTests
         var useCase = new ExportExcel(
             new ExcelExportService(new ExcelStyleProvider()),
             new FileNamingService(),
-            repo,
-            new ExcelExportRegistrationOptions { ConnectionString = "UseDevelopmentStorage=true", ContainerName = "test" });
+            repo);
 
         // When
         var result = await useCase.ExecuteAsync(records, columns, "Report", options);

--- a/DataToExcel.Test/DataToExcel.Test.csproj
+++ b/DataToExcel.Test/DataToExcel.Test.csproj
@@ -19,4 +19,11 @@
   <ItemGroup>
     <ProjectReference Include="../DataToExcel/DataToExcel.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="**/._*" />
+    <None Remove="**/._*" />
+    <Content Remove="**/._*" />
+    <EmbeddedResource Remove="**/._*" />
+    <AdditionalFiles Remove="**/._*" />
+  </ItemGroup>
 </Project>

--- a/DataToExcel.Test/DataToExcel.Test.csproj
+++ b/DataToExcel.Test/DataToExcel.Test.csproj
@@ -1,30 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <Using Include="Xunit" />
     </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Application\" />
-      <Folder Include="IntegrationTest\" />
-      <Folder Include="Repositories\" />
-      <Folder Include="Services\" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="../DataToExcel/DataToExcel.csproj" />
+  </ItemGroup>
 </Project>

--- a/DataToExcel.Test/ExcelExportClientTests.cs
+++ b/DataToExcel.Test/ExcelExportClientTests.cs
@@ -1,0 +1,87 @@
+using System.Data;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel.Models;
+using DataToExcel.Wrappers.Interfaces;
+using Moq;
+using Xunit;
+
+namespace DataToExcel.Test;
+
+public class ExcelExportClientTests
+{
+    [Fact]
+    public void GivenConnectionStringCtor_ShouldInitialize()
+    {
+        // Act
+        var client = new DataToExcel.ExcelExportClient(
+            connectionString: "UseDevelopmentStorage=true",
+            containerName: "reports",
+            defaultSasTtl: TimeSpan.FromMinutes(5));
+
+        // Assert
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void GivenUriCtor_ShouldInitialize()
+    {
+        // Act
+        var client = new DataToExcel.ExcelExportClient(
+            containerUri: new Uri("https://example.com/container"),
+            credential: null,
+            defaultSasTtl: TimeSpan.FromMinutes(5));
+
+        // Assert
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public async Task GivenContainerCtor_WhenExecuteAsync_ThenUploadsBlob()
+    {
+        // Given sample data
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+        var options = new ExcelExportOptions { SheetName = "Names" };
+
+        // Mocks for blob interactions
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var client = new DataToExcel.ExcelExportClient(containerMock.Object, TimeSpan.FromMinutes(5));
+
+        // When
+        var result = await client.ExecuteAsync(records, columns, "Report", options);
+
+        // Then
+        blobMock.Verify(
+            b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.NotNull(result);
+        Assert.EndsWith(".xlsx", result.BlobName);
+    }
+}
+

--- a/DataToExcel.Test/Hosting/DependencyInjectionTests.cs
+++ b/DataToExcel.Test/Hosting/DependencyInjectionTests.cs
@@ -1,0 +1,34 @@
+using DataToExcel.Hosting;
+using DataToExcel.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DataToExcel.Test.Hosting;
+
+public class DependencyInjectionTests
+{
+    [Fact]
+    public void GivenConfigurationWhenAddExcelExportThenOptionsShouldBind()
+    {
+        // Given
+        var settings = new Dictionary<string, string?>
+        {
+            ["ConnectionString"] = "UseDevelopmentStorage=true",
+            ["ContainerName"] = "reports"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        // When
+        var services = new ServiceCollection();
+        services.AddExcelExport(configuration);
+        var provider = services.BuildServiceProvider();
+
+        // Then
+        var opts = provider.GetRequiredService<ExcelExportRegistrationOptions>();
+        Assert.Equal("UseDevelopmentStorage=true", opts.ConnectionString);
+        Assert.Equal("reports", opts.ContainerName);
+    }
+}

--- a/DataToExcel.Test/Integration/ExcelExportClientTests.cs
+++ b/DataToExcel.Test/Integration/ExcelExportClientTests.cs
@@ -1,0 +1,58 @@
+using System.Data;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel;
+using DataToExcel.Models;
+using DataToExcel.Wrappers.Interfaces;
+using Moq;
+using Xunit;
+
+namespace DataToExcel.Test.Integration;
+
+public class ExcelExportClientTests
+{
+    [Fact]
+    public async Task GivenMockedBlobStorageWhenExecuteAsyncThenBlobShouldBeUploaded()
+    {
+        // Given
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var client = new ExcelExportClient(containerMock.Object);
+
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+
+        // When
+        var result = await client.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+
+        // Then
+        blobMock.Verify(
+            b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Equal("test", result.Container);
+    }
+}

--- a/DataToExcel.Test/Integration/IntegrationTests.cs
+++ b/DataToExcel.Test/Integration/IntegrationTests.cs
@@ -1,0 +1,73 @@
+using System.Data;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel.Application.Interfaces;
+using DataToExcel.Hosting;
+using DataToExcel.Models;
+using DataToExcel.Repositories;
+using DataToExcel.Repositories.Interfaces;
+using DataToExcel.Wrappers.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace DataToExcel.Test.Integration;
+
+public class IntegrationTests
+{
+    [Fact]
+    public async Task GivenMockedBlobStorageWhenUseCaseExecutesViaDIThenBlobShouldBeUploaded()
+    {
+        // Given
+        var services = new ServiceCollection();
+        services.AddExcelExport(o =>
+        {
+            o.ConnectionString = "UseDevelopmentStorage=true";
+            o.ContainerName = "test";
+        });
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        services.AddSingleton<IBlobStorageRepository>(sp =>
+            new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5)));
+
+        var provider = services.BuildServiceProvider();
+        var useCase = provider.GetRequiredService<IExportExcel>();
+
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+
+        // When
+        var result = await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+
+        // Then
+        blobMock.Verify(
+            b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Equal("test", result.Container);
+    }
+}

--- a/DataToExcel.Test/Repositories/AzureBlobStorageRepositoryTests.cs
+++ b/DataToExcel.Test/Repositories/AzureBlobStorageRepositoryTests.cs
@@ -1,8 +1,8 @@
-using Azure.Storage.Blobs.Models;
-using Azure.Storage.Sas;
 using DataToExcel.Models;
 using DataToExcel.Repositories;
 using DataToExcel.Wrappers.Interfaces;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
 using Moq;
 using Xunit;
 
@@ -11,49 +11,85 @@ namespace DataToExcel.Test.Repositories;
 public class AzureBlobStorageRepositoryTests
 {
     [Fact]
-    public async Task GivenMockedWrappersWhenUploadExcelAsyncThenRepositoryShouldReturnSuccess()
+    public void Ctor_WithConnectionString_DoesNotThrow()
     {
-        // Given
-        var containerMock = new Mock<IBlobContainerClient>();
-        var blobMock = new Mock<IBlobClient>();
+        var repo = new AzureBlobStorageRepository(
+            connectionString: "UseDevelopmentStorage=true",
+            containerName: "test",
+            defaultTtl: TimeSpan.FromMinutes(5));
+        Assert.NotNull(repo);
+    }
 
-        containerMock.Setup(c => c.Name).Returns("test");
-        containerMock
+    [Fact]
+    public void Ctor_WithUriAndNoCredential_DoesNotThrow()
+    {
+        var repo = new AzureBlobStorageRepository(
+            containerUri: new Uri("https://example.com/container"),
+            credential: null,
+            defaultTtl: TimeSpan.FromMinutes(5));
+        Assert.NotNull(repo);
+    }
+
+    [Fact]
+    public void Ctor_WithContainer_DoesNotThrow()
+    {
+        var container = new Mock<IBlobContainerClient>();
+        var repo = new AzureBlobStorageRepository(container.Object, TimeSpan.FromMinutes(5));
+        Assert.NotNull(repo);
+    }
+
+    [Fact]
+    public async Task UploadExcelAsync_WhenCannotGenerateSas_UsesBlobUri()
+    {
+        // Arrange
+        var container = new Mock<IBlobContainerClient>();
+        var blob = new Mock<IBlobClient>();
+
+        container.Setup(c => c.Name).Returns("test");
+        container
             .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        containerMock
+        container
             .Setup(c => c.GetBlobClient(It.IsAny<string>()))
-            .Returns(blobMock.Object);
+            .Returns(blob.Object);
 
-        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
-        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
-        blobMock
-            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
-            .Returns(new Uri("https://example.com/blob?sas=1"));
-        blobMock
+        blob.Setup(b => b.CanGenerateSasUri).Returns(false); // force else branch
+        var blobUri = new Uri("https://example.com/blob");
+        blob.Setup(b => b.Uri).Returns(blobUri);
+        blob
             .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var repo = new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5));
+        var repo = new AzureBlobStorageRepository(container.Object, TimeSpan.FromMinutes(10));
+        await using var ms = new MemoryStream(new byte[] { 1, 2, 3, 4 });
 
-        using var stream = new MemoryStream(new byte[] {1, 2, 3});
+        // Act
+        var response = await repo.UploadExcelAsync(ms, "file.xlsx", sasTtl: null, ct: default);
 
-        // When
-        var response = await repo.UploadExcelAsync(stream, "file.xlsx", TimeSpan.FromMinutes(1));
-
-        // Then
-        containerMock.Verify(
-            c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()),
-            Times.Once);
-        blobMock.Verify(
-            b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
-            Times.Once);
-
+        // Assert
         Assert.True(response.IsSuccess);
         Assert.NotNull(response.Data);
-        Assert.Equal("test", response.Data!.Container);
-        Assert.Equal("file.xlsx", response.Data!.BlobName);
-        Assert.Equal(new Uri("https://example.com/blob?sas=1"), response.Data!.SasReadUri);
-        Assert.Equal(new Uri("https://example.com/blob"), response.Data!.BlobUri);
+        Assert.Equal(blobUri, response.Data!.SasReadUri);
+    }
+
+    [Fact]
+    public async Task UploadExcelAsync_OnException_ReturnsFailure()
+    {
+        // Arrange
+        var container = new Mock<IBlobContainerClient>();
+        container
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var repo = new AzureBlobStorageRepository(container.Object, TimeSpan.FromMinutes(10));
+        await using var ms = new MemoryStream(new byte[] { 1, 2, 3 });
+
+        // Act
+        var response = await repo.UploadExcelAsync(ms, "file.xlsx", sasTtl: null, ct: default);
+
+        // Assert
+        Assert.False(response.IsSuccess);
+        Assert.NotNull(response.ErrorMessage);
     }
 }
+

--- a/DataToExcel.Test/Repositories/AzureBlobStorageRepositoryTests.cs
+++ b/DataToExcel.Test/Repositories/AzureBlobStorageRepositoryTests.cs
@@ -1,0 +1,59 @@
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel.Models;
+using DataToExcel.Repositories;
+using DataToExcel.Wrappers.Interfaces;
+using Moq;
+using Xunit;
+
+namespace DataToExcel.Test.Repositories;
+
+public class AzureBlobStorageRepositoryTests
+{
+    [Fact]
+    public async Task GivenMockedWrappersWhenUploadExcelAsyncThenRepositoryShouldReturnSuccess()
+    {
+        // Given
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var repo = new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5));
+
+        using var stream = new MemoryStream(new byte[] {1, 2, 3});
+
+        // When
+        var response = await repo.UploadExcelAsync(stream, "file.xlsx", TimeSpan.FromMinutes(1));
+
+        // Then
+        containerMock.Verify(
+            c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()),
+            Times.Once);
+        blobMock.Verify(
+            b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        Assert.True(response.IsSuccess);
+        Assert.NotNull(response.Data);
+        Assert.Equal("test", response.Data!.Container);
+        Assert.Equal("file.xlsx", response.Data!.BlobName);
+        Assert.Equal(new Uri("https://example.com/blob?sas=1"), response.Data!.SasReadUri);
+        Assert.Equal(new Uri("https://example.com/blob"), response.Data!.BlobUri);
+    }
+}

--- a/DataToExcel.Test/Services/ExcelExportServiceTests.cs
+++ b/DataToExcel.Test/Services/ExcelExportServiceTests.cs
@@ -1,0 +1,77 @@
+using System.Data;
+using DataToExcel.Models;
+using DataToExcel.Services;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using System.Linq;
+using Xunit;
+
+namespace DataToExcel.Test.Services;
+
+public class ExcelExportServiceTests
+{
+    [Fact]
+    public async Task GivenRecordsWhenExportAsyncThenHeaderShouldBeWritten()
+    {
+        // Given
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Name","Name", ColumnDataType.String)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        // When
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        // Then
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var header = sheet.GetFirstChild<SheetData>()!.Elements<Row>().First().Elements<Cell>().First().CellValue!.Text;
+        Assert.Equal("Name", header);
+    }
+
+    [Fact]
+    public async Task GivenRecordsWithMultipleColumnsWhenExportAsyncThenValuesShouldBeInCorrectCells()
+    {
+        // Given
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Columns.Add("Age", typeof(int));
+        table.Rows.Add("Alice", 30);
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Name","Name", ColumnDataType.String),
+            new("Age","Age", ColumnDataType.Number)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        // When
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        // Then
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+        var dataRow = rows[1];
+        var cells = dataRow.Elements<Cell>().ToList();
+        Assert.Equal("Alice", cells[0].InnerText);
+        Assert.Equal("30", cells[1].CellValue!.Text);
+    }
+}

--- a/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
+++ b/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
@@ -1,0 +1,23 @@
+using DataToExcel.Models;
+using DataToExcel.Services;
+using Xunit;
+
+namespace DataToExcel.Test.Services;
+
+public class ExcelStyleProviderTests
+{
+    [Fact]
+    public void GivenStyleProviderWhenBuildStylesheetThenMapShouldContainHeaderStyle()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(out var map);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        Assert.NotNull(response.Data);
+        Assert.Equal(1u, map[PredefinedStyle.Header]);
+    }
+}

--- a/DataToExcel.Test/Services/FileNamingServiceTests.cs
+++ b/DataToExcel.Test/Services/FileNamingServiceTests.cs
@@ -1,0 +1,21 @@
+using DataToExcel.Services;
+using Xunit;
+
+namespace DataToExcel.Test.Services;
+
+public class FileNamingServiceTests
+{
+    [Fact]
+    public void GivenRawNameWhenComposeExcelFileNameThenResultShouldBeSanitizedAndFormatted()
+    {
+        // Given
+        var svc = new FileNamingService();
+
+        // When
+        var response = svc.ComposeExcelFileName("Test/Report", new DateTime(2024,1,2), new DateTime(2024,1,3,12,5,6));
+
+        // Then
+        Assert.True(response.IsSuccess);
+        Assert.Equal("Test_Report_20240102_20240103_120506.xlsx", response.Data);
+    }
+}

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -11,17 +11,14 @@ public class ExportExcel : IExportExcel
     private readonly IExcelExportService _excelService;
     private readonly IFileNamingService _namingService;
     private readonly IBlobStorageRepository _blobRepository;
-    private readonly ExcelExportRegistrationOptions _options;
 
     public ExportExcel(IExcelExportService excelService,
         IFileNamingService namingService,
-        IBlobStorageRepository blobRepository,
-        ExcelExportRegistrationOptions options)
+        IBlobStorageRepository blobRepository)
     {
         _excelService = excelService;
         _namingService = namingService;
         _blobRepository = blobRepository;
-        _options = options;
     }
 
     public async Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
@@ -38,7 +35,7 @@ public class ExportExcel : IExportExcel
             throw new InvalidOperationException(nameResponse.ErrorMessage ?? "File name generation failed");
         var fileName = nameResponse.Data;
 
-        var tempFile = Path.GetTempFileName();
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         try
         {
             await using (var fs = new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.SequentialScan))

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -1,0 +1,62 @@
+using System.Data;
+using DataToExcel.Application.Interfaces;
+using DataToExcel.Models;
+using DataToExcel.Repositories.Interfaces;
+using DataToExcel.Services.Interfaces;
+
+namespace DataToExcel.Application;
+
+public class ExportExcel : IExportExcel
+{
+    private readonly IExcelExportService _excelService;
+    private readonly IFileNamingService _namingService;
+    private readonly IBlobStorageRepository _blobRepository;
+    private readonly ExcelExportRegistrationOptions _options;
+
+    public ExportExcel(IExcelExportService excelService,
+        IFileNamingService namingService,
+        IBlobStorageRepository blobRepository,
+        ExcelExportRegistrationOptions options)
+    {
+        _excelService = excelService;
+        _namingService = namingService;
+        _blobRepository = blobRepository;
+        _options = options;
+    }
+
+    public async Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        string baseFileName,
+        ExcelExportOptions options,
+        TimeSpan? sasTtl = null,
+        CancellationToken ct = default)
+    {
+        var created = DateTime.UtcNow;
+        var dataDate = options.DataDateUtc ?? created.Date;
+        var nameResponse = _namingService.ComposeExcelFileName(baseFileName, dataDate, created);
+        if (!nameResponse.IsSuccess || nameResponse.Data is null)
+            throw new InvalidOperationException(nameResponse.ErrorMessage ?? "File name generation failed");
+        var fileName = nameResponse.Data;
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await using (var fs = new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.SequentialScan))
+            {
+                var exportResponse = await _excelService.ExportAsync(data, columns, fs, options, ct);
+                if (!exportResponse.IsSuccess)
+                    throw new InvalidOperationException(exportResponse.ErrorMessage ?? "Excel export failed");
+                fs.Position = 0;
+                var response = await _blobRepository.UploadExcelAsync(fs, fileName, sasTtl, ct);
+                if (!response.IsSuccess || response.Data is null)
+                    throw new InvalidOperationException(response.ErrorMessage ?? "Blob upload failed");
+                return response.Data;
+            }
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}

--- a/DataToExcel/Application/Interfaces/IExportExcel.cs
+++ b/DataToExcel/Application/Interfaces/IExportExcel.cs
@@ -1,0 +1,14 @@
+using System.Data;
+using DataToExcel.Models;
+
+namespace DataToExcel.Application.Interfaces;
+
+public interface IExportExcel
+{
+    Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        string baseFileName,
+        ExcelExportOptions options,
+        TimeSpan? sasTtl = null,
+        CancellationToken ct = default);
+}

--- a/DataToExcel/DataToExcel.csproj
+++ b/DataToExcel/DataToExcel.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <Folder Include="Application\" />
-      <Folder Include="Repositories\" />
-      <Folder Include="Services\" />
-    </ItemGroup>
-
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.18.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/DataToExcel/ExcelExportClient.cs
+++ b/DataToExcel/ExcelExportClient.cs
@@ -1,0 +1,72 @@
+using System.Data;
+using Azure.Core;
+using DataToExcel.Application;
+using DataToExcel.Application.Interfaces;
+using DataToExcel.Models;
+using DataToExcel.Repositories;
+using DataToExcel.Repositories.Interfaces;
+using DataToExcel.Services;
+using DataToExcel.Services.Interfaces;
+using DataToExcel.Wrappers.Interfaces;
+
+namespace DataToExcel;
+
+public class ExcelExportClient : IExportExcel
+{
+    private readonly IExportExcel _inner;
+
+    public ExcelExportClient(string connectionString, string containerName, TimeSpan? defaultSasTtl = null)
+    {
+        var options = new ExcelExportRegistrationOptions
+        {
+            ConnectionString = connectionString,
+            ContainerName = containerName,
+            DefaultSasTtl = defaultSasTtl ?? TimeSpan.FromHours(1)
+        };
+        _inner = Build(options);
+    }
+
+    public ExcelExportClient(Uri containerUri, TokenCredential? credential = null, TimeSpan? defaultSasTtl = null)
+    {
+        var options = new ExcelExportRegistrationOptions
+        {
+            ContainerUri = containerUri,
+            Credential = credential,
+            DefaultSasTtl = defaultSasTtl ?? TimeSpan.FromHours(1)
+        };
+        _inner = Build(options);
+    }
+
+    public ExcelExportClient(IBlobContainerClient container, TimeSpan? defaultSasTtl = null)
+    {
+        var options = new ExcelExportRegistrationOptions
+        {
+            ContainerName = container.Name,
+            DefaultSasTtl = defaultSasTtl ?? TimeSpan.FromHours(1)
+        };
+        _inner = Build(options, container);
+    }
+
+    private static IExportExcel Build(ExcelExportRegistrationOptions options, IBlobContainerClient? container = null)
+    {
+        if (container is null)
+            options.Validate();
+        IExcelStyleProvider style = new ExcelStyleProvider();
+        IExcelExportService export = new ExcelExportService(style);
+        IFileNamingService naming = new FileNamingService();
+        IBlobStorageRepository repo = container is null
+            ? (!string.IsNullOrWhiteSpace(options.ConnectionString)
+                ? new AzureBlobStorageRepository(options.ConnectionString!, options.ContainerName, options.DefaultSasTtl)
+                : new AzureBlobStorageRepository(options.ContainerUri!, options.Credential, options.DefaultSasTtl))
+            : new AzureBlobStorageRepository(container, options.DefaultSasTtl);
+        return new ExportExcel(export, naming, repo, options);
+    }
+
+    public async Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        string baseFileName,
+        ExcelExportOptions options,
+        TimeSpan? sasTtl = null,
+        CancellationToken ct = default) =>
+        await _inner.ExecuteAsync(data, columns, baseFileName, options, sasTtl, ct);
+}

--- a/DataToExcel/ExcelExportClient.cs
+++ b/DataToExcel/ExcelExportClient.cs
@@ -13,7 +13,7 @@ namespace DataToExcel;
 
 public class ExcelExportClient : IExportExcel
 {
-    private readonly IExportExcel _inner;
+    private readonly ExportExcel _inner;
 
     public ExcelExportClient(string connectionString, string containerName, TimeSpan? defaultSasTtl = null)
     {

--- a/DataToExcel/ExcelExportClient.cs
+++ b/DataToExcel/ExcelExportClient.cs
@@ -59,7 +59,7 @@ public class ExcelExportClient : IExportExcel
                 ? new AzureBlobStorageRepository(options.ConnectionString!, options.ContainerName, options.DefaultSasTtl)
                 : new AzureBlobStorageRepository(options.ContainerUri!, options.Credential, options.DefaultSasTtl))
             : new AzureBlobStorageRepository(container, options.DefaultSasTtl);
-        return new ExportExcel(export, naming, repo, options);
+        return new ExportExcel(export, naming, repo);
     }
 
     public async Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,

--- a/DataToExcel/Hosting/DependencyInjection.cs
+++ b/DataToExcel/Hosting/DependencyInjection.cs
@@ -1,0 +1,47 @@
+using DataToExcel.Application;
+using DataToExcel.Application.Interfaces;
+using DataToExcel.Models;
+using DataToExcel.Repositories;
+using DataToExcel.Repositories.Interfaces;
+using DataToExcel.Services;
+using DataToExcel.Services.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DataToExcel.Hosting;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddExcelExport(this IServiceCollection services, Action<ExcelExportRegistrationOptions> configure)
+    {
+        var options = new ExcelExportRegistrationOptions();
+        configure(options);
+        options.Validate();
+
+        services.AddSingleton(options);
+        services.AddTransient<IExcelStyleProvider, ExcelStyleProvider>();
+        services.AddTransient<IExcelExportService, ExcelExportService>();
+        services.AddTransient<IFileNamingService, FileNamingService>();
+        services.AddSingleton<IBlobStorageRepository>(sp =>
+        {
+            if (!string.IsNullOrWhiteSpace(options.ConnectionString))
+                return new AzureBlobStorageRepository(options.ConnectionString!, options.ContainerName, options.DefaultSasTtl);
+            return new AzureBlobStorageRepository(options.ContainerUri!, options.Credential, options.DefaultSasTtl);
+        });
+        services.AddTransient<IExportExcel, ExportExcel>();
+        return services;
+    }
+
+    public static IServiceCollection AddExcelExport(this IServiceCollection services, IConfiguration configuration)
+    {
+        var bound = configuration.Get<ExcelExportRegistrationOptions>() ?? new ExcelExportRegistrationOptions();
+        return services.AddExcelExport(opts =>
+        {
+            opts.ContainerName = bound.ContainerName;
+            opts.ConnectionString = bound.ConnectionString;
+            opts.ContainerUri = bound.ContainerUri;
+            opts.Credential = bound.Credential;
+            opts.DefaultSasTtl = bound.DefaultSasTtl;
+        });
+    }
+}

--- a/DataToExcel/Models/BlobUploadResult.cs
+++ b/DataToExcel/Models/BlobUploadResult.cs
@@ -1,0 +1,8 @@
+namespace DataToExcel.Models;
+
+public record BlobUploadResult(
+    string Container,
+    string BlobName,
+    Uri BlobUri,
+    Uri SasReadUri,
+    long SizeBytes);

--- a/DataToExcel/Models/ColumnDefinition.cs
+++ b/DataToExcel/Models/ColumnDefinition.cs
@@ -1,0 +1,11 @@
+using DataToExcel.Models;
+
+namespace DataToExcel.Models;
+
+public record ColumnDefinition(
+    string FieldName,
+    string Title,
+    ColumnDataType DataType,
+    double? Width = null,
+    PredefinedStyle? Style = null,
+    string? NumberFormatCode = null);

--- a/DataToExcel/Models/ColumnDefinition.cs
+++ b/DataToExcel/Models/ColumnDefinition.cs
@@ -1,5 +1,3 @@
-using DataToExcel.Models;
-
 namespace DataToExcel.Models;
 
 public record ColumnDefinition(

--- a/DataToExcel/Models/Enums.cs
+++ b/DataToExcel/Models/Enums.cs
@@ -1,0 +1,24 @@
+namespace DataToExcel.Models;
+
+public enum ColumnDataType
+{
+    String,
+    Number,
+    DateTime,
+    Boolean,
+    Currency,
+    Percentage
+}
+
+public enum PredefinedStyle
+{
+    Default,
+    Header,
+    Number,
+    Date,
+    DateTime,
+    Currency,
+    Percentage,
+    Boolean,
+    Text
+}

--- a/DataToExcel/Models/ExcelExportOptions.cs
+++ b/DataToExcel/Models/ExcelExportOptions.cs
@@ -1,0 +1,13 @@
+using System.Globalization;
+
+namespace DataToExcel.Models;
+
+public class ExcelExportOptions
+{
+    public string SheetName { get; set; } = "Sheet1";
+    public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+    public bool FreezeHeader { get; set; } = true;
+    public bool AutoFilter { get; set; } = true;
+    public DateTime? DataDateUtc { get; set; }
+        = DateTime.UtcNow.Date;
+}

--- a/DataToExcel/Models/ExcelExportOptions.cs
+++ b/DataToExcel/Models/ExcelExportOptions.cs
@@ -8,6 +8,5 @@ public class ExcelExportOptions
     public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
     public bool FreezeHeader { get; set; } = true;
     public bool AutoFilter { get; set; } = true;
-    public DateTime? DataDateUtc { get; set; }
-        = DateTime.UtcNow.Date;
+    public DateTime? DataDateUtc { get; set; } = DateTime.UtcNow.Date;
 }

--- a/DataToExcel/Models/ExcelExportRegistrationOptions.cs
+++ b/DataToExcel/Models/ExcelExportRegistrationOptions.cs
@@ -16,7 +16,7 @@ public class ExcelExportRegistrationOptions
         var hasUri = ContainerUri is not null;
         if (hasConn == hasUri)
             throw new InvalidOperationException("Specify either ConnectionString or ContainerUri but not both.");
-        if (!hasConn && string.IsNullOrWhiteSpace(ContainerName))
+        if (hasConn && string.IsNullOrWhiteSpace(ContainerName))
             throw new InvalidOperationException("ContainerName is required when using ConnectionString.");
     }
 }

--- a/DataToExcel/Models/ExcelExportRegistrationOptions.cs
+++ b/DataToExcel/Models/ExcelExportRegistrationOptions.cs
@@ -1,0 +1,22 @@
+using Azure.Core;
+
+namespace DataToExcel.Models;
+
+public class ExcelExportRegistrationOptions
+{
+    public string ContainerName { get; set; } = string.Empty;
+    public TimeSpan DefaultSasTtl { get; set; } = TimeSpan.FromHours(1);
+    public string? ConnectionString { get; set; }
+    public Uri? ContainerUri { get; set; }
+    public TokenCredential? Credential { get; set; }
+
+    public void Validate()
+    {
+        var hasConn = !string.IsNullOrWhiteSpace(ConnectionString);
+        var hasUri = ContainerUri is not null;
+        if (hasConn == hasUri)
+            throw new InvalidOperationException("Specify either ConnectionString or ContainerUri but not both.");
+        if (!hasConn && string.IsNullOrWhiteSpace(ContainerName))
+            throw new InvalidOperationException("ContainerName is required when using ConnectionString.");
+    }
+}

--- a/DataToExcel/Models/RepositoryResponse.cs
+++ b/DataToExcel/Models/RepositoryResponse.cs
@@ -1,0 +1,15 @@
+namespace DataToExcel.Models;
+
+public class RepositoryResponse<T> where T : class
+{
+    public T? Data { get; set; }
+    public string? ErrorMessage { get; set; }
+    public bool IsSuccess { get; set; }
+
+    public RepositoryResponse() { }
+    public RepositoryResponse(T data)
+    {
+        Data = data;
+        IsSuccess = true;
+    }
+}

--- a/DataToExcel/Models/ServiceResponse.cs
+++ b/DataToExcel/Models/ServiceResponse.cs
@@ -1,0 +1,15 @@
+namespace DataToExcel.Models;
+
+public class ServiceResponse<T> where T : class
+{
+    public T? Data { get; set; }
+    public string? ErrorMessage { get; set; }
+    public bool IsSuccess { get; set; }
+
+    public ServiceResponse() { }
+    public ServiceResponse(T data)
+    {
+        Data = data;
+        IsSuccess = true;
+    }
+}

--- a/DataToExcel/Repositories/AzureBlobStorageRepository.cs
+++ b/DataToExcel/Repositories/AzureBlobStorageRepository.cs
@@ -1,0 +1,83 @@
+using Azure;
+using Azure.Core;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel.Models;
+using DataToExcel.Repositories.Interfaces;
+using DataToExcel.Wrappers;
+using DataToExcel.Wrappers.Interfaces;
+
+namespace DataToExcel.Repositories;
+
+public class AzureBlobStorageRepository : IBlobStorageRepository
+{
+    private readonly IBlobContainerClient _container;
+    private readonly TimeSpan _defaultTtl;
+
+    public AzureBlobStorageRepository(string connectionString, string containerName, TimeSpan defaultTtl)
+        : this(new BlobContainerClientWrapper(new BlobContainerClient(connectionString, containerName)), defaultTtl)
+    {
+    }
+
+    public AzureBlobStorageRepository(Uri containerUri, TokenCredential? credential, TimeSpan defaultTtl)
+        : this(
+            new BlobContainerClientWrapper(
+                credential is null
+                    ? new BlobContainerClient(containerUri)
+                    : new BlobContainerClient(containerUri, credential)),
+            defaultTtl)
+    {
+    }
+
+    public AzureBlobStorageRepository(IBlobContainerClient container, TimeSpan defaultTtl)
+    {
+        _container = container;
+        _defaultTtl = defaultTtl;
+    }
+
+    public async Task<RepositoryResponse<BlobUploadResult>> UploadExcelAsync(Stream excelStream, string blobName, TimeSpan? sasTtl, CancellationToken ct = default)
+    {
+        try
+        {
+            await _container.CreateIfNotExistsAsync(PublicAccessType.None, ct);
+            var blobClient = _container.GetBlobClient(blobName);
+            excelStream.Position = 0;
+            var options = new BlobUploadOptions
+            {
+                HttpHeaders = new BlobHttpHeaders { ContentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+                TransferOptions = new StorageTransferOptions
+                {
+                    InitialTransferSize = 8 * 1024 * 1024,
+                    MaximumTransferSize = 8 * 1024 * 1024,
+                    MaximumConcurrency = Environment.ProcessorCount
+                }
+            };
+            await blobClient.UploadAsync(excelStream, options, ct);
+
+            var expiry = DateTimeOffset.UtcNow.Add(sasTtl ?? _defaultTtl);
+            Uri sasUri;
+            if (blobClient.CanGenerateSasUri)
+            {
+                var builder = new BlobSasBuilder(BlobSasPermissions.Read, expiry)
+                {
+                    BlobContainerName = _container.Name,
+                    BlobName = blobName
+                };
+                sasUri = blobClient.GenerateSasUri(builder);
+            }
+            else
+            {
+                sasUri = blobClient.Uri; // fallback without SAS
+            }
+
+            var result = new BlobUploadResult(_container.Name, blobName, blobClient.Uri, sasUri, excelStream.Length);
+            return new RepositoryResponse<BlobUploadResult>(result) { IsSuccess = true };
+        }
+        catch (Exception ex)
+        {
+            return new RepositoryResponse<BlobUploadResult> { IsSuccess = false, ErrorMessage = ex.Message };
+        }
+    }
+}

--- a/DataToExcel/Repositories/Interfaces/IBlobStorageRepository.cs
+++ b/DataToExcel/Repositories/Interfaces/IBlobStorageRepository.cs
@@ -1,0 +1,8 @@
+using DataToExcel.Models;
+
+namespace DataToExcel.Repositories.Interfaces;
+
+public interface IBlobStorageRepository
+{
+    Task<RepositoryResponse<BlobUploadResult>> UploadExcelAsync(Stream excelStream, string blobName, TimeSpan? sasTtl, CancellationToken ct = default);
+}

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -1,0 +1,194 @@
+using System.Data;
+using System.Globalization;
+using DataToExcel.Models;
+using DataToExcel.Services.Interfaces;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace DataToExcel.Services;
+
+public class ExcelExportService : IExcelExportService
+{
+    private readonly IExcelStyleProvider _styleProvider;
+    public ExcelExportService(IExcelStyleProvider styleProvider)
+        => _styleProvider = styleProvider;
+
+    public async Task<ServiceResponse<Stream>> ExportAsync(IEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        Stream output,
+        ExcelExportOptions options,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            if (!output.CanSeek)
+                throw new ArgumentException("Stream must be seekable", nameof(output));
+
+            var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
+            if (!styleResponse.IsSuccess || styleResponse.Data is null)
+                return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
+            var stylesheet = styleResponse.Data;
+
+            using var document = SpreadsheetDocument.Create(output, SpreadsheetDocumentType.Workbook, true);
+            var workbookPart = document.AddWorkbookPart();
+            workbookPart.Workbook = new Workbook();
+            var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+            stylesPart.Stylesheet = stylesheet;
+            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+
+        using (var writer = OpenXmlWriter.Create(worksheetPart))
+        {
+            writer.WriteStartElement(new Worksheet());
+
+            if (options.FreezeHeader)
+            {
+                writer.WriteStartElement(new SheetViews());
+                writer.WriteElement(new SheetView
+                {
+                    WorkbookViewId = 0,
+                    Pane = new Pane
+                    {
+                        VerticalSplit = 1,
+                        TopLeftCell = "A2",
+                        ActivePane = PaneValues.BottomLeft,
+                        State = PaneStateValues.Frozen
+                    }
+                });
+                writer.WriteEndElement(); // SheetViews
+            }
+
+            if (columns.Any(c => c.Width.HasValue))
+            {
+                writer.WriteStartElement(new Columns());
+                uint i = 1;
+                foreach (var col in columns)
+                {
+                    if (col.Width.HasValue)
+                    {
+                        writer.WriteElement(new Column
+                        {
+                            Min = i,
+                            Max = i,
+                            Width = col.Width.Value,
+                            CustomWidth = true
+                        });
+                    }
+                    i++;
+                }
+                writer.WriteEndElement(); // Columns
+            }
+
+            writer.WriteStartElement(new SheetData());
+            // Header
+            writer.WriteStartElement(new Row());
+            foreach (var col in columns)
+            {
+                writer.WriteElement(new Cell
+                {
+                    DataType = CellValues.String,
+                    CellValue = new CellValue(col.Title),
+                    StyleIndex = styleMap[PredefinedStyle.Header]
+                });
+            }
+            writer.WriteEndElement(); // Row
+
+            foreach (var record in data)
+            {
+                ct.ThrowIfCancellationRequested();
+                writer.WriteStartElement(new Row());
+                foreach (var col in columns)
+                {
+                    var value = record[col.FieldName];
+                    if (value == DBNull.Value || value is null)
+                    {
+                        writer.WriteElement(new Cell());
+                        continue;
+                    }
+                    var cell = CreateCell(value, col, styleMap);
+                    writer.WriteElement(cell);
+                }
+                writer.WriteEndElement();
+            }
+            writer.WriteEndElement(); // SheetData
+
+            if (options.AutoFilter)
+            {
+                var endCol = GetColumnName(columns.Count);
+                writer.WriteElement(new AutoFilter { Reference = $"A1:{endCol}1" });
+            }
+
+            writer.WriteEndElement(); // Worksheet
+            writer.Close();
+        }
+
+            var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+            sheets.Append(new Sheet
+            {
+                Id = workbookPart.GetIdOfPart(worksheetPart),
+                SheetId = 1,
+                Name = options.SheetName
+            });
+            workbookPart.Workbook.Save();
+            await output.FlushAsync(ct);
+            return new ServiceResponse<Stream>(output) { IsSuccess = true };
+        }
+        catch (Exception ex)
+        {
+            return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = ex.Message };
+        }
+    }
+
+    private static Cell CreateCell(object value, ColumnDefinition col,
+        IReadOnlyDictionary<PredefinedStyle, uint> styleMap)
+    {
+        var style = col.Style ?? GetStyleFromDataType(col.DataType);
+        var cell = new Cell { StyleIndex = styleMap[style] };
+        switch (col.DataType)
+        {
+            case ColumnDataType.Number:
+            case ColumnDataType.Currency:
+            case ColumnDataType.Percentage:
+                cell.DataType = CellValues.Number;
+                cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+                break;
+            case ColumnDataType.DateTime:
+                cell.DataType = CellValues.Number;
+                var dt = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
+                cell.CellValue = new CellValue(dt.ToOADate().ToString(CultureInfo.InvariantCulture));
+                break;
+            case ColumnDataType.Boolean:
+                cell.DataType = CellValues.Boolean;
+                cell.CellValue = new CellValue((bool)value ? "1" : "0");
+                break;
+            default:
+                cell.DataType = CellValues.InlineString;
+                cell.InlineString = new InlineString(new Text(value.ToString()));
+                break;
+        }
+        return cell;
+    }
+
+    private static PredefinedStyle GetStyleFromDataType(ColumnDataType type) => type switch
+    {
+        ColumnDataType.Number => PredefinedStyle.Number,
+        ColumnDataType.DateTime => PredefinedStyle.DateTime,
+        ColumnDataType.Boolean => PredefinedStyle.Boolean,
+        ColumnDataType.Currency => PredefinedStyle.Currency,
+        ColumnDataType.Percentage => PredefinedStyle.Percentage,
+        _ => PredefinedStyle.Text
+    };
+
+    private static string GetColumnName(int index)
+    {
+        var dividend = index;
+        var columnName = string.Empty;
+        while (dividend > 0)
+        {
+            var modulo = (dividend - 1) % 26;
+            columnName = Convert.ToChar(65 + modulo) + columnName;
+            dividend = (dividend - modulo) / 26;
+        }
+        return columnName;
+    }
+}

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -130,7 +130,7 @@ public class ExcelExportService : IExcelExportService
             writer.WriteElement(new Cell
             {
                 DataType = CellValues.String,
-                CellValue = new CellValue(col.Title),
+                CellValue = new CellValue(col.Title ?? string.Empty),
                 StyleIndex = styleMap[PredefinedStyle.Header]
             });
         }
@@ -180,7 +180,7 @@ public class ExcelExportService : IExcelExportService
             case ColumnDataType.Currency:
             case ColumnDataType.Percentage:
                 cell.DataType = CellValues.Number;
-                cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+                cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
                 break;
             case ColumnDataType.DateTime:
                 cell.DataType = CellValues.Number;
@@ -193,7 +193,8 @@ public class ExcelExportService : IExcelExportService
                 break;
             default:
                 cell.DataType = CellValues.InlineString;
-                cell.InlineString = new InlineString(new Text(value.ToString()));
+                var s = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+                cell.InlineString = new InlineString(new Text(s));
                 break;
         }
         return cell;

--- a/DataToExcel/Services/ExcelStyleProvider.cs
+++ b/DataToExcel/Services/ExcelStyleProvider.cs
@@ -1,0 +1,87 @@
+using DataToExcel.Models;
+using DataToExcel.Services.Interfaces;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace DataToExcel.Services;
+
+public class ExcelStyleProvider : IExcelStyleProvider
+{
+    public ServiceResponse<Stylesheet> BuildStylesheet(out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap)
+    {
+        try
+        {
+            var fonts = new Fonts(
+                new Font(),
+                new Font(new Bold())
+            );
+            var fills = new Fills(
+                new Fill(new PatternFill { PatternType = PatternValues.None }),
+                new Fill(new PatternFill { PatternType = PatternValues.Gray125 })
+            );
+            var borders = new Borders(new Border());
+            var cellStyleFormats = new CellStyleFormats(new CellFormat());
+
+            uint nfId = 164; // custom formats
+            var numberingFormats = new NumberingFormats();
+            var cellFormats = new List<CellFormat>
+            {
+                new(),                                // 0 default
+                new() { FontId = 1, ApplyFont = true } // 1 header
+            };
+
+            // number
+            numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "#,##0.00" });
+            cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
+            var numberIdx = (uint)cellFormats.Count - 1; nfId++;
+
+            // date
+            numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "yyyy-mm-dd" });
+            cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
+            var dateIdx = (uint)cellFormats.Count - 1; nfId++;
+
+            // datetime
+            numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "yyyy-mm-dd hh:mm:ss" });
+            cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
+            var dateTimeIdx = (uint)cellFormats.Count - 1; nfId++;
+
+            // currency
+            numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "#,##0.00" });
+            cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
+            var currencyIdx = (uint)cellFormats.Count - 1; nfId++;
+
+            // percentage
+            numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "0.00%" });
+            cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
+            var percentageIdx = (uint)cellFormats.Count - 1; nfId++;
+
+            // boolean
+            cellFormats.Add(new());
+            var boolIdx = (uint)cellFormats.Count - 1;
+
+            // text
+            cellFormats.Add(new() { });
+            var textIdx = (uint)cellFormats.Count - 1;
+
+            styleIndexMap = new Dictionary<PredefinedStyle, uint>
+            {
+                [PredefinedStyle.Default] = 0,
+                [PredefinedStyle.Header] = 1,
+                [PredefinedStyle.Number] = numberIdx,
+                [PredefinedStyle.Date] = dateIdx,
+                [PredefinedStyle.DateTime] = dateTimeIdx,
+                [PredefinedStyle.Currency] = currencyIdx,
+                [PredefinedStyle.Percentage] = percentageIdx,
+                [PredefinedStyle.Boolean] = boolIdx,
+                [PredefinedStyle.Text] = textIdx
+            };
+
+            var stylesheet = new Stylesheet(numberingFormats, fonts, fills, borders, cellStyleFormats, new CellFormats(cellFormats));
+            return new ServiceResponse<Stylesheet>(stylesheet) { IsSuccess = true };
+        }
+        catch (Exception ex)
+        {
+            styleIndexMap = new Dictionary<PredefinedStyle, uint>();
+            return new ServiceResponse<Stylesheet> { IsSuccess = false, ErrorMessage = ex.Message };
+        }
+    }
+}

--- a/DataToExcel/Services/ExcelStyleProvider.cs
+++ b/DataToExcel/Services/ExcelStyleProvider.cs
@@ -32,27 +32,31 @@ public class ExcelStyleProvider : IExcelStyleProvider
             // number
             numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "#,##0.00" });
             cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
-            var numberIdx = (uint)cellFormats.Count - 1; nfId++;
+            var numberIdx = (uint)cellFormats.Count - 1;
+            nfId++;
 
             // date
             numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "yyyy-mm-dd" });
             cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
-            var dateIdx = (uint)cellFormats.Count - 1; nfId++;
+            var dateIdx = (uint)cellFormats.Count - 1;
+            nfId++;
 
             // datetime
             numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "yyyy-mm-dd hh:mm:ss" });
             cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
-            var dateTimeIdx = (uint)cellFormats.Count - 1; nfId++;
+            var dateTimeIdx = (uint)cellFormats.Count - 1;
+            nfId++;
 
             // currency
             numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "#,##0.00" });
             cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
-            var currencyIdx = (uint)cellFormats.Count - 1; nfId++;
+            var currencyIdx = (uint)cellFormats.Count - 1;
+            nfId++;
 
             // percentage
             numberingFormats.Append(new NumberingFormat { NumberFormatId = nfId, FormatCode = "0.00%" });
             cellFormats.Add(new() { NumberFormatId = nfId, ApplyNumberFormat = true });
-            var percentageIdx = (uint)cellFormats.Count - 1; nfId++;
+            var percentageIdx = (uint)cellFormats.Count - 1;
 
             // boolean
             cellFormats.Add(new());

--- a/DataToExcel/Services/FileNamingService.cs
+++ b/DataToExcel/Services/FileNamingService.cs
@@ -1,0 +1,22 @@
+using DataToExcel.Models;
+using DataToExcel.Services.Interfaces;
+
+namespace DataToExcel.Services;
+
+public class FileNamingService : IFileNamingService
+{
+    public ServiceResponse<string> ComposeExcelFileName(string baseName, DateTime dataDateUtc, DateTime creationUtc)
+    {
+        try
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            var sanitized = new string(baseName.Select(c => invalid.Contains(c) ? '_' : c).ToArray());
+            var name = $"{sanitized}_{dataDateUtc:yyyyMMdd}_{creationUtc:yyyyMMdd_HHmmss}.xlsx";
+            return new ServiceResponse<string>(name) { IsSuccess = true };
+        }
+        catch (Exception ex)
+        {
+            return new ServiceResponse<string> { IsSuccess = false, ErrorMessage = ex.Message };
+        }
+    }
+}

--- a/DataToExcel/Services/Interfaces/IExcelExportService.cs
+++ b/DataToExcel/Services/Interfaces/IExcelExportService.cs
@@ -1,0 +1,13 @@
+using System.Data;
+using DataToExcel.Models;
+
+namespace DataToExcel.Services.Interfaces;
+
+public interface IExcelExportService
+{
+    Task<ServiceResponse<Stream>> ExportAsync(IEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        Stream output,
+        ExcelExportOptions options,
+        CancellationToken ct = default);
+}

--- a/DataToExcel/Services/Interfaces/IExcelStyleProvider.cs
+++ b/DataToExcel/Services/Interfaces/IExcelStyleProvider.cs
@@ -1,0 +1,9 @@
+using DocumentFormat.OpenXml.Spreadsheet;
+using DataToExcel.Models;
+
+namespace DataToExcel.Services.Interfaces;
+
+public interface IExcelStyleProvider
+{
+    ServiceResponse<Stylesheet> BuildStylesheet(out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap);
+}

--- a/DataToExcel/Services/Interfaces/IFileNamingService.cs
+++ b/DataToExcel/Services/Interfaces/IFileNamingService.cs
@@ -1,0 +1,8 @@
+using DataToExcel.Models;
+
+namespace DataToExcel.Services.Interfaces;
+
+public interface IFileNamingService
+{
+    ServiceResponse<string> ComposeExcelFileName(string baseName, DateTime dataDateUtc, DateTime creationUtc);
+}

--- a/DataToExcel/Wrappers/BlobClientWrapper.cs
+++ b/DataToExcel/Wrappers/BlobClientWrapper.cs
@@ -1,10 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using DataToExcel.Wrappers.Interfaces;
 
 namespace DataToExcel.Wrappers;
-
+[ExcludeFromCodeCoverage]
 public class BlobClientWrapper : IBlobClient
 {
     private readonly BlobClient _inner;

--- a/DataToExcel/Wrappers/BlobClientWrapper.cs
+++ b/DataToExcel/Wrappers/BlobClientWrapper.cs
@@ -1,0 +1,22 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+using DataToExcel.Wrappers.Interfaces;
+
+namespace DataToExcel.Wrappers;
+
+public class BlobClientWrapper : IBlobClient
+{
+    private readonly BlobClient _inner;
+
+    public BlobClientWrapper(BlobClient inner) => _inner = inner;
+
+    public bool CanGenerateSasUri => _inner.CanGenerateSasUri;
+
+    public Uri Uri => _inner.Uri;
+
+    public async Task UploadAsync(Stream content, BlobUploadOptions options, CancellationToken ct)
+        => await _inner.UploadAsync(content, options, ct);
+
+    public Uri GenerateSasUri(BlobSasBuilder builder) => _inner.GenerateSasUri(builder);
+}

--- a/DataToExcel/Wrappers/BlobContainerClientWrapper.cs
+++ b/DataToExcel/Wrappers/BlobContainerClientWrapper.cs
@@ -1,9 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using DataToExcel.Wrappers.Interfaces;
 
 namespace DataToExcel.Wrappers;
 
+[ExcludeFromCodeCoverage]
 public class BlobContainerClientWrapper : IBlobContainerClient
 {
     private readonly BlobContainerClient _inner;

--- a/DataToExcel/Wrappers/BlobContainerClientWrapper.cs
+++ b/DataToExcel/Wrappers/BlobContainerClientWrapper.cs
@@ -1,0 +1,19 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using DataToExcel.Wrappers.Interfaces;
+
+namespace DataToExcel.Wrappers;
+
+public class BlobContainerClientWrapper : IBlobContainerClient
+{
+    private readonly BlobContainerClient _inner;
+
+    public BlobContainerClientWrapper(BlobContainerClient inner) => _inner = inner;
+
+    public string Name => _inner.Name;
+
+    public async Task CreateIfNotExistsAsync(PublicAccessType accessType, CancellationToken ct)
+        => await _inner.CreateIfNotExistsAsync(accessType, cancellationToken: ct);
+
+    public IBlobClient GetBlobClient(string blobName) => new BlobClientWrapper(_inner.GetBlobClient(blobName));
+}

--- a/DataToExcel/Wrappers/Interfaces/IBlobClient.cs
+++ b/DataToExcel/Wrappers/Interfaces/IBlobClient.cs
@@ -1,0 +1,12 @@
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+
+namespace DataToExcel.Wrappers.Interfaces;
+
+public interface IBlobClient
+{
+    bool CanGenerateSasUri { get; }
+    Uri Uri { get; }
+    Task UploadAsync(Stream content, BlobUploadOptions options, CancellationToken ct);
+    Uri GenerateSasUri(BlobSasBuilder builder);
+}

--- a/DataToExcel/Wrappers/Interfaces/IBlobContainerClient.cs
+++ b/DataToExcel/Wrappers/Interfaces/IBlobContainerClient.cs
@@ -1,0 +1,10 @@
+using Azure.Storage.Blobs.Models;
+
+namespace DataToExcel.Wrappers.Interfaces;
+
+public interface IBlobContainerClient
+{
+    string Name { get; }
+    Task CreateIfNotExistsAsync(PublicAccessType accessType, CancellationToken ct);
+    IBlobClient GetBlobClient(string blobName);
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
 # DataToExcel
+
+DataToExcel is a .NET 8 library that converts an `IEnumerable<IDataRecord>` into a streaming Excel file (`.xlsx`) and uploads it securely to Azure Blob Storage.
+
+## Features
+- Stream-based OpenXML writing for exports up to roughly 1 GB
+- Predefined styles for currency, date, datetime, percentage, number, boolean, and text
+- File names formatted as `<BaseName>_<DataDate:yyyyMMdd>_<Creation:yyyyMMdd_HHmmss>.xlsx`
+- Secure upload to private containers with temporary read-only SAS links
+- Works with dependency injection or as a standalone client
+
+## Using dependency injection
+1. Add the required NuGet packages to your project: `DocumentFormat.OpenXml`, `Azure.Storage.Blobs`, and `Azure.Identity`.
+2. Register the exporter in your `IServiceCollection` by calling `AddExcelExport`.
+3. Resolve `IExportExcel` and call `ExecuteAsync`.
+
+```csharp
+var services = new ServiceCollection();
+services.AddExcelExport(options =>
+{
+    options.ConnectionString = "<SecureConnectionString>";
+    options.ContainerName = "reports";
+    options.DefaultSasTtl = TimeSpan.FromHours(2);
+});
+
+var provider = services.BuildServiceProvider();
+var exporter = provider.GetRequiredService<IExportExcel>();
+
+var result = await exporter.ExecuteAsync(
+    data: records,
+    columns: columns,
+    baseFileName: "Sales",
+    options: new ExcelExportOptions
+    {
+        SheetName = "Sales",
+        DataDateUtc = new DateTime(2025, 8, 1),
+        FreezeHeader = true,
+        AutoFilter = true
+    },
+    ct: CancellationToken.None);
+```
+
+### Binding options from configuration
+Store the connection string and other settings in `appsettings.json`, environment variables, or user secrets and bind them directly:
+
+```json
+{
+  "ExcelExport": {
+    "ConnectionString": "<SecureConnectionString>",
+    "ContainerName": "reports",
+    "DefaultSasTtl": "02:00:00"
+  }
+}
+```
+
+```csharp
+var services = new ServiceCollection();
+services.AddExcelExport(configuration.GetSection("ExcelExport"));
+```
+
+## Using the standalone client
+When dependency injection is not available, instantiate `ExcelExportClient` directly. Two constructors are provided: one for connection strings and another for RBAC/AAD scenarios.
+
+```csharp
+// Using a connection string
+var client = new ExcelExportClient("<SecureConnectionString>", "reports");
+
+// Or using a container URI and optional credential (for RBAC/AAD)
+var client = new ExcelExportClient(new Uri("https://account.blob.core.windows.net/reports"));
+
+var result = await client.ExecuteAsync(
+    data: records,
+    columns: columns,
+    baseFileName: "Sales",
+    options: new ExcelExportOptions { SheetName = "Sales" },
+    ct: CancellationToken.None);
+```
+
+The `ExecuteAsync` method returns a `BlobUploadResult` with the blob URI, SAS URI, and uploaded size.
+
+## NuGet requirements
+- DocumentFormat.OpenXml
+- Azure.Storage.Blobs
+- Azure.Identity (for RBAC/AAD scenarios)
+
+## Limitations
+- Maximum of 1,048,576 rows per worksheet
+- `IAsyncEnumerable<IDataRecord>` and worksheet splitting are not yet implemented
+
+## Performance and security notes
+- Uses `OpenXmlWriter` with a temporary `FileStream` to keep memory usage low
+- Files are uploaded to private containers and returned with a short-lived read-only SAS token


### PR DESCRIPTION
## Summary
- Implement Excel export service using OpenXML streaming
- Add Azure Blob repository and DI/standalone client
- Provide comprehensive unit and integration tests
- Wrap BlobContainerClient to enable mocking in tests
- Ensure all Task-returning methods use the async keyword
- Return RepositoryResponse from blob repository methods for success/error propagation
- Wrap all service-layer methods in ServiceResponse for consistent error handling
- Mock blob storage via wrapper interfaces in the integration test
- Replace fake blob storage repository tests with Moq-based wrapper mocks
- Rename export use case to `ExportExcel` and add standalone client test
- Expand README with detailed usage instructions for DI and standalone client
- Allow DI registration to bind connection strings from configuration
- Rename test methods using Given-When-Then convention and add `// Given // When // Then` comments
- Verify exported Excel cell values are written to the expected row and column

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b43f2f39c883208f7f31b2eda22425