### PR TITLE
Add grouped and hidden column features

### DIFF
--- a/DataToExcel.Test/Services/ExcelExportServiceTests.cs
+++ b/DataToExcel.Test/Services/ExcelExportServiceTests.cs
@@ -17,9 +17,12 @@ public class ExcelExportServiceTests
         var table = new DataTable();
         table.Columns.Add("Name", typeof(string));
         table.Rows.Add("Alice");
-        var reader = table.CreateDataReader();
-        var records = new List<IDataRecord>();
-        while (reader.Read()) records.Add(reader);
+        IEnumerable<IDataRecord> Records()
+        {
+            var reader = table.CreateDataReader();
+            while (reader.Read()) yield return reader;
+        }
+        var records = Records();
 
         var columns = new List<ColumnDefinition>
         {
@@ -48,9 +51,12 @@ public class ExcelExportServiceTests
         table.Columns.Add("Name", typeof(string));
         table.Columns.Add("Age", typeof(int));
         table.Rows.Add("Alice", 30);
-        var reader = table.CreateDataReader();
-        var records = new List<IDataRecord>();
-        while (reader.Read()) records.Add(reader);
+        IEnumerable<IDataRecord> Records2()
+        {
+            var reader = table.CreateDataReader();
+            while (reader.Read()) yield return reader;
+        }
+        var records = Records2();
 
         var columns = new List<ColumnDefinition>
         {
@@ -73,5 +79,77 @@ public class ExcelExportServiceTests
         var cells = dataRow.Elements<Cell>().ToList();
         Assert.Equal("Alice", cells[0].InnerText);
         Assert.Equal("30", cells[1].CellValue!.Text);
+    }
+
+    [Fact]
+    public async Task GivenHiddenColumnWhenExportAsyncThenColumnShouldBeHidden()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        IEnumerable<IDataRecord> Records3()
+        {
+            var reader = table.CreateDataReader();
+            while (reader.Read()) yield return reader;
+        }
+        var records = Records3();
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Name","Name", ColumnDataType.String, Hidden: true)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var column = sheet.GetFirstChild<Columns>()!.Elements<Column>().First();
+        Assert.True(column.Hidden!.Value);
+    }
+
+    [Fact]
+    public async Task GivenGroupedColumnWhenExportAsyncThenRowsShouldBeGrouped()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("Amount", typeof(int));
+        table.Rows.Add("A", 1);
+        table.Rows.Add("A", 2);
+        table.Rows.Add("B", 3);
+        IEnumerable<IDataRecord> Records4()
+        {
+            var reader = table.CreateDataReader();
+            while (reader.Read()) yield return reader;
+        }
+        var records = Records4();
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category","Category", ColumnDataType.String, Group: true),
+            new("Amount","Amount", ColumnDataType.Number)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Equal("A", rows[1].Elements<Cell>().First().InnerText);
+        Assert.Null(rows[1].OutlineLevel);
+        Assert.Equal((byte)1, rows[2].OutlineLevel!.Value);
+        Assert.Equal("", rows[2].Elements<Cell>().First().InnerText);
+        Assert.Equal("B", rows[3].Elements<Cell>().First().InnerText);
+        var sheetFormat = sheet.Elements<SheetFormatProperties>().FirstOrDefault();
+        Assert.NotNull(sheetFormat);
+        Assert.Equal((byte)1, sheetFormat!.OutlineLevelRow!.Value);
     }
 }

--- a/DataToExcel/Models/ColumnDefinition.cs
+++ b/DataToExcel/Models/ColumnDefinition.cs
@@ -6,4 +6,6 @@ public record ColumnDefinition(
     ColumnDataType DataType,
     double? Width = null,
     PredefinedStyle? Style = null,
-    string? NumberFormatCode = null);
+    string? NumberFormatCode = null,
+    bool Hidden = false,
+    bool Group = false);

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -118,7 +118,7 @@ public class ExcelExportService : IExcelExportService
                 {
                     Min = i,
                     Max = i,
-                    Hidden = col.Hidden ? true : (BooleanValue?)null
+                    Hidden = col.Hidden ? true : null
                 };
                 if (col.Width.HasValue)
                 {
@@ -155,8 +155,10 @@ public class ExcelExportService : IExcelExportService
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
         CancellationToken ct)
     {
-        var groupIndex = columns.Select((c, i) => new { c, i }).FirstOrDefault(x => x.c.Group)?.i;
-        string? groupField = groupIndex.HasValue ? columns[groupIndex.Value].FieldName : null;
+        var groupInfo = columns.Select((c, i) => new { c, i }).FirstOrDefault(x => x.c.Group);
+        var hasGroup = groupInfo is not null;
+        var groupIndexValue = hasGroup ? groupInfo.i : -1;
+        string? groupField = hasGroup ? columns[groupIndexValue].FieldName : null;
         object? currentGroup = null;
 
         foreach (var record in data)
@@ -182,7 +184,7 @@ public class ExcelExportService : IExcelExportService
             for (int i = 0; i < columns.Count; i++)
             {
                 var col = columns[i];
-                if (groupField is not null && i == groupIndex && !isGroupRow)
+                if (groupField is not null && i == groupIndexValue && !isGroupRow)
                 {
                     writer.WriteElement(new Cell());
                     continue;


### PR DESCRIPTION
## Summary
- allow marking columns as hidden or grouping columns in ColumnDefinition
- export grouped rows with outline formatting and hide columns when specified
- add unit tests for grouping and hidden column support

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b52164d08c8320b694017b28a1a901