### PR TITLE
Add forward-only async grouped integration test and grouped export tests across layers

### DIFF
--- a/DataToExcel.Test/Application/ExportExcelTests.cs
+++ b/DataToExcel.Test/Application/ExportExcelTests.cs
@@ -1,12 +1,15 @@
 using System.Data;
-using DataToExcel.Application;
-using DataToExcel.Application.Interfaces;
+using System.Linq;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
+using DataToExcel.Application;
+using DataToExcel.Application.Interfaces;
 using DataToExcel.Models;
 using DataToExcel.Repositories;
 using DataToExcel.Services;
 using DataToExcel.Wrappers.Interfaces;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using Moq;
 using Xunit;
 
@@ -171,6 +174,132 @@ public class ExportExcelTests
         Assert.EndsWith(".xlsx", result.BlobName);
     }
 
+    [Fact]
+    public async Task GivenGroupedColumnsWhenExecuteAsyncThenGroupedRowsAreWritten()
+    {
+        var table = BuildGroupedTable();
+        var records = ToRecords(table);
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category","Category", ColumnDataType.String, Group: true),
+            new("Amount","Amount", ColumnDataType.Number)
+        };
+        var options = new ExcelExportOptions { SheetName = "Grouped" };
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+        var captured = new MemoryStream();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((stream, _, _) =>
+            {
+                stream.Position = 0;
+                stream.CopyTo(captured);
+            })
+            .Returns(Task.CompletedTask);
+
+        var repo = new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5));
+        var registrationOptions = new ExcelExportRegistrationOptions();
+        IExportExcel useCase = new ExportExcel(
+            new ExcelExportService(new ExcelStyleProvider()),
+            new FileNamingService(),
+            repo,
+            registrationOptions);
+
+        var result = await useCase.ExecuteAsync(records, columns, "Report", options);
+
+        Assert.NotNull(result);
+        captured.Position = 0;
+        using var doc = SpreadsheetDocument.Open(captured, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Equal(20, rows.Skip(1).Count());
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
+    }
+
+    [Fact]
+    public async Task GivenForwardOnlyAsyncRecordsWhenExecuteAsyncThenGroupedRowsAreWritten()
+    {
+        var table = BuildGroupedTable();
+        var records = new ForwardOnlyAsyncRecords(table);
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category","Category", ColumnDataType.String, Group: true),
+            new("Amount","Amount", ColumnDataType.Number)
+        };
+        var options = new ExcelExportOptions { SheetName = "Grouped" };
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+        var captured = new MemoryStream();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((stream, _, _) =>
+            {
+                stream.Position = 0;
+                stream.CopyTo(captured);
+            })
+            .Returns(Task.CompletedTask);
+
+        var repo = new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5));
+        var registrationOptions = new ExcelExportRegistrationOptions();
+        IExportExcel useCase = new ExportExcel(
+            new ExcelExportService(new ExcelStyleProvider()),
+            new FileNamingService(),
+            repo,
+            registrationOptions);
+
+        var result = await useCase.ExecuteAsync(records, columns, "Report", options);
+
+        Assert.NotNull(result);
+        captured.Position = 0;
+        using var doc = SpreadsheetDocument.Open(captured, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Equal(20, rows.Skip(1).Count());
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
+    }
+
     private static (Mock<IBlobContainerClient> containerMock,
         IExportExcel useCase,
         List<IDataRecord> records,
@@ -224,6 +353,76 @@ public class ExportExcelTests
         {
             yield return record;
             await Task.Yield();
+        }
+    }
+
+    private static DataTable BuildGroupedTable()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("Amount", typeof(int));
+
+        var groups = new[] { "A", "B", "C", "D" };
+        foreach (var group in groups)
+        {
+            for (var i = 1; i <= 5; i++)
+            {
+                table.Rows.Add(group, ((Array.IndexOf(groups, group) * 5) + i) * 10);
+            }
+        }
+
+        return table;
+    }
+
+    private static IEnumerable<IDataRecord> ToRecords(DataTable table)
+    {
+        var reader = table.CreateDataReader();
+        while (reader.Read())
+        {
+            yield return reader;
+        }
+    }
+
+    private sealed class ForwardOnlyAsyncRecords : IAsyncEnumerable<IDataRecord>, IAsyncEnumerator<IDataRecord>
+    {
+        private readonly DataTable _table;
+        private DataTableReader? _reader;
+        private bool _started;
+
+        public ForwardOnlyAsyncRecords(DataTable table)
+        {
+            _table = table;
+        }
+
+        public IDataRecord Current => _reader ?? throw new InvalidOperationException("Enumerator not started.");
+
+        public IAsyncEnumerator<IDataRecord> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (_started)
+            {
+                throw new InvalidOperationException("This enumerator can only be iterated once.");
+            }
+
+            _started = true;
+            _reader = _table.CreateDataReader();
+            return this;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _reader?.Dispose();
+            _reader = null;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            if (_reader is null)
+            {
+                throw new InvalidOperationException("Enumerator not started.");
+            }
+
+            return new ValueTask<bool>(_reader.Read());
         }
     }
 }

--- a/DataToExcel.Test/Integration/IntegrationTests.cs
+++ b/DataToExcel.Test/Integration/IntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Linq;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using DataToExcel.Application.Interfaces;
@@ -7,6 +8,8 @@ using DataToExcel.Models;
 using DataToExcel.Repositories;
 using DataToExcel.Repositories.Interfaces;
 using DataToExcel.Wrappers.Interfaces;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
@@ -69,5 +72,209 @@ public class IntegrationTests
             b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()),
             Times.Once);
         Assert.Equal("test", result.Container);
+    }
+
+    [Fact]
+    public async Task GivenGroupedColumnsWhenUseCaseExecutesViaDIThenGroupedRowsAreWritten()
+    {
+        var services = new ServiceCollection();
+        services.AddExcelExport(o =>
+        {
+            o.ConnectionString = "UseDevelopmentStorage=true";
+            o.ContainerName = "test";
+        });
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+        var captured = new MemoryStream();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((stream, _, _) =>
+            {
+                stream.Position = 0;
+                stream.CopyTo(captured);
+            })
+            .Returns(Task.CompletedTask);
+
+        services.AddSingleton<IBlobStorageRepository>(sp =>
+            new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5)));
+
+        var provider = services.BuildServiceProvider();
+        var useCase = provider.GetRequiredService<IExportExcel>();
+
+        var table = BuildGroupedTable();
+        var records = ToRecords(table);
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category", "Category", ColumnDataType.String, Group: true),
+            new("Amount", "Amount", ColumnDataType.Number)
+        };
+
+        var result = await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+
+        Assert.NotNull(result);
+        captured.Position = 0;
+        using var doc = SpreadsheetDocument.Open(captured, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Equal(20, rows.Skip(1).Count());
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
+    }
+
+    [Fact]
+    public async Task GivenForwardOnlyAsyncRecordsWhenUseCaseExecutesViaDIThenGroupedRowsAreWritten()
+    {
+        var services = new ServiceCollection();
+        services.AddExcelExport(o =>
+        {
+            o.ConnectionString = "UseDevelopmentStorage=true";
+            o.ContainerName = "test";
+        });
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+        var captured = new MemoryStream();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((stream, _, _) =>
+            {
+                stream.Position = 0;
+                stream.CopyTo(captured);
+            })
+            .Returns(Task.CompletedTask);
+
+        services.AddSingleton<IBlobStorageRepository>(sp =>
+            new AzureBlobStorageRepository(containerMock.Object, TimeSpan.FromMinutes(5)));
+
+        var provider = services.BuildServiceProvider();
+        var useCase = provider.GetRequiredService<IExportExcel>();
+
+        var table = BuildGroupedTable();
+        var records = new ForwardOnlyAsyncRecords(table);
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category", "Category", ColumnDataType.String, Group: true),
+            new("Amount", "Amount", ColumnDataType.Number)
+        };
+
+        var result = await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+
+        Assert.NotNull(result);
+        captured.Position = 0;
+        using var doc = SpreadsheetDocument.Open(captured, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Equal(20, rows.Skip(1).Count());
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
+    }
+
+    private static DataTable BuildGroupedTable()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("Amount", typeof(int));
+
+        var groups = new[] { "A", "B", "C", "D" };
+        foreach (var group in groups)
+        {
+            for (var i = 1; i <= 5; i++)
+            {
+                table.Rows.Add(group, ((Array.IndexOf(groups, group) * 5) + i) * 10);
+            }
+        }
+
+        return table;
+    }
+
+    private static IEnumerable<IDataRecord> ToRecords(DataTable table)
+    {
+        var reader = table.CreateDataReader();
+        while (reader.Read())
+        {
+            yield return reader;
+        }
+    }
+
+    private sealed class ForwardOnlyAsyncRecords : IAsyncEnumerable<IDataRecord>, IAsyncEnumerator<IDataRecord>
+    {
+        private readonly DataTable _table;
+        private DataTableReader? _reader;
+        private bool _started;
+
+        public ForwardOnlyAsyncRecords(DataTable table)
+        {
+            _table = table;
+        }
+
+        public IDataRecord Current => _reader ?? throw new InvalidOperationException("Enumerator not started.");
+
+        public IAsyncEnumerator<IDataRecord> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (_started)
+            {
+                throw new InvalidOperationException("This enumerator can only be iterated once.");
+            }
+
+            _started = true;
+            _reader = _table.CreateDataReader();
+            return this;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _reader?.Dispose();
+            _reader = null;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            if (_reader is null)
+            {
+                throw new InvalidOperationException("Enumerator not started.");
+            }
+
+            return new ValueTask<bool>(_reader.Read());
+        }
     }
 }

--- a/DataToExcel.Test/Services/ExcelExportServiceTests.cs
+++ b/DataToExcel.Test/Services/ExcelExportServiceTests.cs
@@ -194,18 +194,8 @@ public class ExcelExportServiceTests
     [Fact]
     public async Task GivenGroupedColumnWhenExportAsyncThenRowsShouldBeGrouped()
     {
-        var table = new DataTable();
-        table.Columns.Add("Category", typeof(string));
-        table.Columns.Add("Amount", typeof(int));
-        table.Rows.Add("A", 1);
-        table.Rows.Add("A", 2);
-        table.Rows.Add("B", 3);
-        IEnumerable<IDataRecord> Records4()
-        {
-            var reader = table.CreateDataReader();
-            while (reader.Read()) yield return reader;
-        }
-        var records = Records4();
+        var table = BuildGroupedTable();
+        var records = ToRecords(table);
 
         var columns = new List<ColumnDefinition>
         {
@@ -224,10 +214,15 @@ public class ExcelExportServiceTests
         var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
 
         Assert.Equal("A", rows[1].Elements<Cell>().First().InnerText);
-        Assert.Null(rows[1].OutlineLevel);
-        Assert.Equal((byte)1, rows[2].OutlineLevel!.Value);
-        Assert.Equal("", rows[2].Elements<Cell>().First().InnerText);
-        Assert.Equal("B", rows[3].Elements<Cell>().First().InnerText);
+        Assert.Equal("B", rows[6].Elements<Cell>().First().InnerText);
+        Assert.Equal("C", rows[11].Elements<Cell>().First().InnerText);
+        Assert.Equal("D", rows[16].Elements<Cell>().First().InnerText);
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
         var sheetFormat = sheet.Elements<SheetFormatProperties>().FirstOrDefault();
         Assert.NotNull(sheetFormat);
         Assert.Equal((byte)1, sheetFormat!.OutlineLevelRow!.Value);
@@ -236,12 +231,7 @@ public class ExcelExportServiceTests
     [Fact]
     public async Task GivenGroupedColumnWhenExportAsyncAsyncRecordsThenRowsShouldBeGrouped()
     {
-        var table = new DataTable();
-        table.Columns.Add("Category", typeof(string));
-        table.Columns.Add("Amount", typeof(int));
-        table.Rows.Add("A", 1);
-        table.Rows.Add("A", 2);
-        table.Rows.Add("B", 3);
+        var table = BuildGroupedTable();
         var records = ToAsyncEnumerable(table);
 
         var columns = new List<ColumnDefinition>
@@ -261,13 +251,172 @@ public class ExcelExportServiceTests
         var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
 
         Assert.Equal("A", rows[1].Elements<Cell>().First().InnerText);
-        Assert.Null(rows[1].OutlineLevel);
-        Assert.Equal((byte)1, rows[2].OutlineLevel!.Value);
-        Assert.Equal("", rows[2].Elements<Cell>().First().InnerText);
-        Assert.Equal("B", rows[3].Elements<Cell>().First().InnerText);
+        Assert.Equal("B", rows[6].Elements<Cell>().First().InnerText);
+        Assert.Equal("C", rows[11].Elements<Cell>().First().InnerText);
+        Assert.Equal("D", rows[16].Elements<Cell>().First().InnerText);
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
         var sheetFormat = sheet.Elements<SheetFormatProperties>().FirstOrDefault();
         Assert.NotNull(sheetFormat);
         Assert.Equal((byte)1, sheetFormat!.OutlineLevelRow!.Value);
+    }
+
+    [Fact]
+    public async Task GivenGroupedMiddleColumnWhenExportAsyncThenRowsShouldBeGrouped()
+    {
+        var table = BuildGroupedTable(withItem: true);
+        var records = ToRecords(table);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Item","Item", ColumnDataType.String),
+            new("Category","Category", ColumnDataType.String, Group: true),
+            new("Amount","Amount", ColumnDataType.Number)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        var firstGroupRowCells = rows[1].Elements<Cell>().ToList();
+        Assert.Null(rows[1].OutlineLevel);
+        Assert.Equal("Item A-1", firstGroupRowCells[0].InnerText);
+        Assert.Equal("A", firstGroupRowCells[1].InnerText);
+        Assert.Equal("10", firstGroupRowCells[2].CellValue!.Text);
+
+        var groupedDetailCells = rows[2].Elements<Cell>().ToList();
+        Assert.Equal((byte)1, rows[2].OutlineLevel!.Value);
+        Assert.Equal("Item A-2", groupedDetailCells[0].InnerText);
+        Assert.Equal(string.Empty, groupedDetailCells[1].InnerText);
+        Assert.Equal("20", groupedDetailCells[2].CellValue!.Text);
+
+        var secondGroupRowCells = rows[6].Elements<Cell>().ToList();
+        Assert.Null(rows[6].OutlineLevel);
+        Assert.Equal("Item B-1", secondGroupRowCells[0].InnerText);
+        Assert.Equal("B", secondGroupRowCells[1].InnerText);
+        Assert.Equal("60", secondGroupRowCells[2].CellValue!.Text);
+    }
+
+    [Fact]
+    public async Task GivenGroupedMiddleColumnWhenExportAsyncAsyncRecordsThenRowsShouldBeGrouped()
+    {
+        var table = BuildGroupedTable(withItem: true);
+        var records = ToAsyncEnumerable(table);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Item","Item", ColumnDataType.String),
+            new("Category","Category", ColumnDataType.String, Group: true),
+            new("Amount","Amount", ColumnDataType.Number)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        var firstGroupRowCells = rows[1].Elements<Cell>().ToList();
+        Assert.Null(rows[1].OutlineLevel);
+        Assert.Equal("Item A-1", firstGroupRowCells[0].InnerText);
+        Assert.Equal("A", firstGroupRowCells[1].InnerText);
+        Assert.Equal("10", firstGroupRowCells[2].CellValue!.Text);
+
+        var groupedDetailCells = rows[2].Elements<Cell>().ToList();
+        Assert.Equal((byte)1, rows[2].OutlineLevel!.Value);
+        Assert.Equal("Item A-2", groupedDetailCells[0].InnerText);
+        Assert.Equal(string.Empty, groupedDetailCells[1].InnerText);
+        Assert.Equal("20", groupedDetailCells[2].CellValue!.Text);
+
+        var secondGroupRowCells = rows[6].Elements<Cell>().ToList();
+        Assert.Null(rows[6].OutlineLevel);
+        Assert.Equal("Item B-1", secondGroupRowCells[0].InnerText);
+        Assert.Equal("B", secondGroupRowCells[1].InnerText);
+        Assert.Equal("60", secondGroupRowCells[2].CellValue!.Text);
+    }
+
+    [Fact]
+    public async Task GivenForwardOnlyAsyncRecordsWhenExportAsyncThenRowsShouldBeGrouped()
+    {
+        var table = BuildGroupedTable();
+        var records = new ForwardOnlyAsyncRecords(table);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category","Category", ColumnDataType.String, Group: true),
+            new("Amount","Amount", ColumnDataType.Number)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.WorksheetParts.First().Worksheet;
+        var rows = sheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Equal(20, rows.Skip(1).Count());
+        Assert.Equal(4, rows.Skip(1).Count(r => r.OutlineLevel is null));
+        Assert.Equal(16, rows.Skip(1).Count(r => r.OutlineLevel?.Value == 1));
+        Assert.All(rows.Skip(1).Where(r => r.OutlineLevel?.Value == 1), r =>
+        {
+            Assert.Equal(string.Empty, r.Elements<Cell>().First().InnerText);
+        });
+    }
+
+    private static DataTable BuildGroupedTable(bool withItem = false)
+    {
+        var table = new DataTable();
+        if (withItem)
+        {
+            table.Columns.Add("Item", typeof(string));
+        }
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("Amount", typeof(int));
+
+        var groups = new[] { "A", "B", "C", "D" };
+        foreach (var group in groups)
+        {
+            for (var i = 1; i <= 5; i++)
+            {
+                var amount = ((Array.IndexOf(groups, group) * 5) + i) * 10;
+                if (withItem)
+                {
+                    table.Rows.Add($"Item {group}-{i}", group, amount);
+                }
+                else
+                {
+                    table.Rows.Add(group, amount);
+                }
+            }
+        }
+
+        return table;
+    }
+
+    private static IEnumerable<IDataRecord> ToRecords(DataTable table)
+    {
+        var reader = table.CreateDataReader();
+        while (reader.Read())
+        {
+            yield return reader;
+        }
     }
 
     private static async IAsyncEnumerable<IDataRecord> ToAsyncEnumerable(DataTable table)
@@ -277,6 +426,49 @@ public class ExcelExportServiceTests
         {
             await Task.Yield();
             yield return reader;
+        }
+    }
+
+    private sealed class ForwardOnlyAsyncRecords : IAsyncEnumerable<IDataRecord>, IAsyncEnumerator<IDataRecord>
+    {
+        private readonly DataTable _table;
+        private DataTableReader? _reader;
+        private bool _started;
+
+        public ForwardOnlyAsyncRecords(DataTable table)
+        {
+            _table = table;
+        }
+
+        public IDataRecord Current => _reader ?? throw new InvalidOperationException("Enumerator not started.");
+
+        public IAsyncEnumerator<IDataRecord> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (_started)
+            {
+                throw new InvalidOperationException("This enumerator can only be iterated once.");
+            }
+
+            _started = true;
+            _reader = _table.CreateDataReader();
+            return this;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _reader?.Dispose();
+            _reader = null;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            if (_reader is null)
+            {
+                throw new InvalidOperationException("Enumerator not started.");
+            }
+
+            return new ValueTask<bool>(_reader.Read());
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the Excel exporter writes grouped rows correctly for a larger dataset and leaves the group cell empty for detail rows when grouping is applied. 
- Validate grouping behavior when the grouped column appears in the middle of the column list. 
- Verify the exporter works with forward-only `IAsyncEnumerable` sources that can only be iterated once across the service and integration layers.

### Description
- Added integration tests `GivenGroupedColumnsWhenUseCaseExecutesViaDIThenGroupedRowsAreWritten` and `GivenForwardOnlyAsyncRecordsWhenUseCaseExecutesViaDIThenGroupedRowsAreWritten` in `IntegrationTests.cs` that capture the uploaded Excel stream and assert outline levels and empty group-detail cells. 
- Added `ForwardOnlyAsyncRecords`, `BuildGroupedTable`, and `ToRecords` helpers to simulate forward-only async enumerables and produce grouped test data, and reused the same helpers in `ExportExcelTests.cs` and `ExcelExportServiceTests.cs`. 
- Expanded `ExcelExportServiceTests` with larger grouped datasets, tests for a grouped column placed in the middle, async enumerable scenarios, and forward-only async enumerables. 
- Extended `ExportExcelTests` to include grouped and forward-only async grouped scenarios that verify generated blobs and spreadsheet structure using `DocumentFormat.OpenXml`.

### Testing
- Ran the full test suite with `dotnet test /workspace/DataToExcel/DataToExcel.sln`. 
- All tests passed: `Passed: 38, Failed: 0, Skipped: 0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714c70eda8832083e1f0c6afd66b01)