### PR TITLE
Build disconnected DataRow before writing Excel cells

### DIFF
--- a/DataToExcel.Test/Services/ExcelExportServiceTests.cs
+++ b/DataToExcel.Test/Services/ExcelExportServiceTests.cs
@@ -387,9 +387,9 @@ public class ExcelExportServiceTests
         table.Columns.Add("Name", typeof(string));
         table.Columns.Add("Age", typeof(int));
         table.Rows.Add("Alice", 30);
-        var queryBuilder = new PostgreQueryBuilder(table)
+        var queryBuilder = new DataTableProjectionBuilder(table)
             .Select("Age", "Name");
-        var executor = new PostgreQueryExecutor();
+        var executor = new DataTableProjectionExecutor();
         var records = executor.ExecuteAsync(queryBuilder);
 
         var columns = new List<ColumnDefinition>
@@ -508,17 +508,17 @@ public class ExcelExportServiceTests
         }
     }
 
-    private sealed class PostgreQueryBuilder
+    private sealed class DataTableProjectionBuilder
     {
         private readonly DataTable _table;
         private IReadOnlyList<string> _selectedColumns = Array.Empty<string>();
 
-        public PostgreQueryBuilder(DataTable table)
+        public DataTableProjectionBuilder(DataTable table)
         {
             _table = table;
         }
 
-        public PostgreQueryBuilder Select(params string[] columns)
+        public DataTableProjectionBuilder Select(params string[] columns)
         {
             _selectedColumns = columns;
             return this;
@@ -547,9 +547,9 @@ public class ExcelExportServiceTests
         }
     }
 
-    private sealed class PostgreQueryExecutor
+    private sealed class DataTableProjectionExecutor
     {
-        public IAsyncEnumerable<IDataRecord> ExecuteAsync(PostgreQueryBuilder builder)
+        public IAsyncEnumerable<IDataRecord> ExecuteAsync(DataTableProjectionBuilder builder)
         {
             var table = builder.Build();
             return new ForwardOnlyAsyncRecords(table);

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -257,6 +257,7 @@ public class ExcelExportService : IExcelExportService
         int groupIndexValue,
         bool isGroupRow)
     {
+        var dataRow = CreateDisconnectedRow(record, columns);
         for (int i = 0; i < columns.Count; i++)
         {
             var col = columns[i];
@@ -266,7 +267,7 @@ public class ExcelExportService : IExcelExportService
                 continue;
             }
 
-            var value = record[col.FieldName];
+            var value = dataRow[col.FieldName];
             if (value == DBNull.Value || value is null)
             {
                 writer.WriteElement(new Cell());
@@ -276,6 +277,23 @@ public class ExcelExportService : IExcelExportService
             var cell = CreateCell(value, col, styleMap);
             writer.WriteElement(cell);
         }
+    }
+
+    private static DataRow CreateDisconnectedRow(IDataRecord record, IReadOnlyList<ColumnDefinition> columns)
+    {
+        var table = new DataTable();
+        foreach (var col in columns)
+        {
+            table.Columns.Add(col.FieldName, typeof(object));
+        }
+
+        var row = table.NewRow();
+        foreach (var col in columns)
+        {
+            row[col.FieldName] = record[col.FieldName] ?? DBNull.Value;
+        }
+
+        return row;
     }
 
     private static void WriteAutoFilter(OpenXmlWriter writer, ExcelExportOptions options, int columnCount)


### PR DESCRIPTION
### Motivation
- Ensure all column values are materialized into a disconnected row before per-cell processing to avoid multiple `IDataRecord` indexer accesses and support forward-only record streams.
- Make cell-emission logic operate against a stable, in-memory row representation to simplify handling of projection/column-order differences.

### Description
- Updated `WriteRowCells` to call `CreateDisconnectedRow` and read cell values from the resulting `DataRow` instead of directly from the `IDataRecord`.
- Added helper `CreateDisconnectedRow(IDataRecord, IReadOnlyList<ColumnDefinition>)` which builds a temporary `DataTable` and populates a disconnected `DataRow` with `DBNull.Value` fallback.
- Extended tests in `DataToExcel.Test/Services/ExcelExportServiceTests.cs` with `GivenForwardOnlyAsyncRecordsWithColumnOrderMismatchWhenExportAsyncThenCellsFollowColumnDefinition` and lightweight test-only helpers `PostgreQueryBuilder` and `PostgreQueryExecutor` to exercise column-order projections.

### Testing
- No automated tests were executed for this change (no `dotnet test` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ae85edc48320a5e645a143f99c2b)