### PR TITLE
Add test for multi-file splitting and support multi-file/multi-sheet exports when row limit exceeded

### DIFF
--- a/DataToExcel.Test/ExcelExportClientTests.cs
+++ b/DataToExcel.Test/ExcelExportClientTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Linq;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using DataToExcel.Models;
@@ -86,7 +87,7 @@ public class ExcelExportClientTests
             blobPrefix: "exports/finance");
 
         // When
-        var result = await client.ExecuteAsync(records, columns, "Report", options);
+        var result = (await client.ExecuteAsync(records, columns, "Report", options)).Single();
 
         // Then
         containerMock.Verify(
@@ -137,7 +138,7 @@ public class ExcelExportClientTests
         var client = new DataToExcel.ExcelExportClient(containerMock.Object, TimeSpan.FromMinutes(5));
 
         // When
-        var result = await client.ExecuteAsync(records, columns, "Report", options);
+        var result = (await client.ExecuteAsync(records, columns, "Report", options)).Single();
 
         // Then
         containerMock.Verify(
@@ -187,7 +188,7 @@ public class ExcelExportClientTests
         var client = new DataToExcel.ExcelExportClient(containerMock.Object, TimeSpan.FromMinutes(5));
 
         // When
-        var result = await client.ExecuteAsync(ToAsyncEnumerable(records), columns, "Report", options);
+        var result = (await client.ExecuteAsync(ToAsyncEnumerable(records), columns, "Report", options)).Single();
 
         // Then
         blobMock.Verify(

--- a/DataToExcel.Test/Integration/ExcelExportClientTests.cs
+++ b/DataToExcel.Test/Integration/ExcelExportClientTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Linq;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using DataToExcel;
@@ -47,7 +48,7 @@ public class ExcelExportClientTests
         var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
 
         // When
-        var result = await client.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+        var result = (await client.ExecuteAsync(records, columns, "Report", new ExcelExportOptions())).Single();
 
         // Then
         blobMock.Verify(

--- a/DataToExcel.Test/Integration/IntegrationTests.cs
+++ b/DataToExcel.Test/Integration/IntegrationTests.cs
@@ -65,7 +65,7 @@ public class IntegrationTests
         var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
 
         // When
-        var result = await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+        var result = (await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions())).Single();
 
         // Then
         blobMock.Verify(
@@ -124,7 +124,7 @@ public class IntegrationTests
             new("Amount", "Amount", ColumnDataType.Number)
         };
 
-        var result = await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+        var result = (await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions())).Single();
 
         Assert.NotNull(result);
         captured.Position = 0;
@@ -191,7 +191,7 @@ public class IntegrationTests
             new("Amount", "Amount", ColumnDataType.Number)
         };
 
-        var result = await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions());
+        var result = (await useCase.ExecuteAsync(records, columns, "Report", new ExcelExportOptions())).Single();
 
         Assert.NotNull(result);
         captured.Position = 0;

--- a/DataToExcel.Test/Utilities/AsyncEnumerableHelpersTests.cs
+++ b/DataToExcel.Test/Utilities/AsyncEnumerableHelpersTests.cs
@@ -1,0 +1,105 @@
+using System.Data;
+using DataToExcel.Utilities;
+using Xunit;
+
+namespace DataToExcel.Test.Utilities;
+
+public class AsyncEnumerableHelpersTests
+{
+    [Fact]
+    public async Task ToAsyncEnumerableReturnsItemsInOrder()
+    {
+        var items = new List<IDataRecord>
+        {
+            new FakeDataRecord("A"),
+            new FakeDataRecord("B")
+        };
+
+        var results = new List<string>();
+        await foreach (var record in AsyncEnumerableHelpers.ToAsyncEnumerable(items, CancellationToken.None))
+        {
+            results.Add(record.GetString(0));
+        }
+
+        Assert.Equal(new[] { "A", "B" }, results);
+    }
+
+    [Fact]
+    public async Task ToAsyncEnumerableHonorsCancellation()
+    {
+        var items = new List<IDataRecord> { new FakeDataRecord("A") };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in AsyncEnumerableHelpers.ToAsyncEnumerable(items, cts.Token))
+            {
+            }
+        });
+    }
+
+    [Fact]
+    public async Task BufferedAsyncRecordEnumeratorPeeksAndConsumes()
+    {
+        var items = new List<IDataRecord>
+        {
+            new FakeDataRecord("A"),
+            new FakeDataRecord("B")
+        };
+
+        await using var enumerator = AsyncEnumerableHelpers.ToAsyncEnumerable(items, CancellationToken.None)
+            .GetAsyncEnumerator();
+        var buffered = new BufferedAsyncRecordEnumerator(enumerator);
+
+        Assert.True(await buffered.TryPeekNextAsync());
+        Assert.Equal("A", buffered.Current?.GetString(0));
+
+        Assert.True(await buffered.TryGetNextAsync());
+        Assert.Equal("A", buffered.Current?.GetString(0));
+
+        Assert.True(await buffered.TryGetNextAsync());
+        Assert.Equal("B", buffered.Current?.GetString(0));
+
+        Assert.False(await buffered.TryGetNextAsync());
+        Assert.Null(buffered.Current);
+    }
+
+    private sealed class FakeDataRecord : IDataRecord
+    {
+        private readonly string _value;
+
+        public FakeDataRecord(string value)
+            => _value = value;
+
+        public int FieldCount => 1;
+        public object this[int i] => _value;
+        public object this[string name] => _value;
+        public bool GetBoolean(int i) => false;
+        public byte GetByte(int i) => 0;
+        public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => 0;
+        public char GetChar(int i) => _value[0];
+        public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => 0;
+        public IDataReader GetData(int i) => throw new NotSupportedException();
+        public string GetDataTypeName(int i) => "string";
+        public DateTime GetDateTime(int i) => DateTime.MinValue;
+        public decimal GetDecimal(int i) => 0;
+        public double GetDouble(int i) => 0;
+        public Type GetFieldType(int i) => typeof(string);
+        public float GetFloat(int i) => 0;
+        public Guid GetGuid(int i) => Guid.Empty;
+        public short GetInt16(int i) => 0;
+        public int GetInt32(int i) => 0;
+        public long GetInt64(int i) => 0;
+        public string GetName(int i) => "Value";
+        public int GetOrdinal(string name) => 0;
+        public string GetString(int i) => _value;
+        public object GetValue(int i) => _value;
+        public int GetValues(object[] values)
+        {
+            values[0] = _value;
+            return 1;
+        }
+        public bool IsDBNull(int i) => false;
+    }
+}

--- a/DataToExcel.Test/Utilities/AsyncEnumerableHelpersTests.cs
+++ b/DataToExcel.Test/Utilities/AsyncEnumerableHelpersTests.cs
@@ -6,6 +6,8 @@ namespace DataToExcel.Test.Utilities;
 
 public class AsyncEnumerableHelpersTests
 {
+    private static readonly string[] ExpectedValues = { "A", "B" };
+
     [Fact]
     public async Task ToAsyncEnumerableReturnsItemsInOrder()
     {
@@ -21,7 +23,7 @@ public class AsyncEnumerableHelpersTests
             results.Add(record.GetString(0));
         }
 
-        Assert.Equal(new[] { "A", "B" }, results);
+        Assert.Equal(ExpectedValues, results);
     }
 
     [Fact]

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -129,7 +129,7 @@ public class ExportExcel : IExportExcel
     {
         var (dataDate, created) = ResolveDates(request.Options);
         var fileNameBase = request.BaseGeneratedName ?? BuildBaseFileName(request.BaseFileName, dataDate, created);
-        var fileName = request.AppendFileIndex
+        var fileName = request.ShouldAppendFileIndex
             ? AppendFileIndex(fileNameBase, request.FileIndex)
             : fileNameBase;
         var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
@@ -159,7 +159,7 @@ public class ExportExcel : IExportExcel
         ExcelExportOptions Options,
         TimeSpan? SasTtl,
         Func<Stream, Task<ServiceResponse<Stream>>> Export,
-        bool AppendFileIndex,
+        bool ShouldAppendFileIndex,
         int FileIndex);
 
     private static async IAsyncEnumerable<IDataRecord> TakeNext(BufferedAsyncRecordEnumerator enumerator, int maxRows,

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -190,7 +190,7 @@ public class ExportExcel : IExportExcel
         return $"{name}_part{fileIndex:D2}{extension}";
     }
 
-    private (DateTime dataDate, DateTime created) ResolveDates(ExcelExportOptions options)
+    private static (DateTime dataDate, DateTime created) ResolveDates(ExcelExportOptions options)
     {
         var created = DateTime.UtcNow;
         var dataDate = options.DataDateUtc ?? created.Date;
@@ -211,7 +211,7 @@ public class ExportExcel : IExportExcel
         return nameResponse.Data;
     }
 
-    private async Task<FileStream> ExportToTempFileAsync(
+    private static async Task<FileStream> ExportToTempFileAsync(
         Func<Stream, Task<ServiceResponse<Stream>>> export,
         CancellationToken ct)
     {

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -86,7 +86,7 @@ public class ExportExcel : IExportExcel
             () =>
             {
                 var chunk = TakeNext(bufferedEnumerator, ExcelExportLimits.MaxDataRowsPerSheet, ct);
-                return ExportToTempFileAsync(stream => _excelService.ExportAsync(chunk, columns, stream, exportOptions, ct), ct);
+                return ExportToTempFileAsync(stream => _excelService.ExportAsync(chunk, columns, stream, exportOptions, ct));
             },
             () => bufferedEnumerator.TryPeekNextAsync(),
             ct);
@@ -216,8 +216,7 @@ public class ExportExcel : IExportExcel
     }
 
     private static async Task<FileStream> ExportToTempFileAsync(
-        Func<Stream, Task<ServiceResponse<Stream>>> export,
-        CancellationToken ct)
+        Func<Stream, Task<ServiceResponse<Stream>>> export)
     {
         var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         var fs = new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.SequentialScan);

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -49,11 +49,11 @@ public class ExportExcel : IExportExcel
                 options,
                 sasTtl,
                 stream => _excelService.ExportAsync(data, columns, stream, options, ct),
-                ct,
                 appendFileIndex: false,
-                fileIndex: 1));
+                fileIndex: 1,
+                ct: ct));
 
-    private async Task<IReadOnlyList<BlobUploadResult>> ExecuteAsyncCore(
+    private static async Task<IReadOnlyList<BlobUploadResult>> ExecuteAsyncCore(
         ExcelExportOptions options,
         Func<Task<IReadOnlyList<BlobUploadResult>>> executeMultiFileAsync,
         Func<Task<BlobUploadResult>> executeSingleAsync)
@@ -128,9 +128,9 @@ public class ExportExcel : IExportExcel
         ExcelExportOptions options,
         TimeSpan? sasTtl,
         Func<Stream, Task<ServiceResponse<Stream>>> export,
-        CancellationToken ct,
         bool appendFileIndex,
-        int fileIndex)
+        int fileIndex,
+        CancellationToken ct)
     {
         var (dataDate, created) = ResolveDates(options);
         var fileNameBase = baseGeneratedName ?? BuildBaseFileName(baseFileName, dataDate, created);

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Runtime.CompilerServices;
 using DataToExcel.Application.Interfaces;
 using DataToExcel.Models;
 using DataToExcel.Repositories.Interfaces;
@@ -24,45 +25,149 @@ public class ExportExcel : IExportExcel
         _registrationOptions = registrationOptions;
     }
 
-    public async Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
+    public async Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,
         ExcelExportOptions options,
         TimeSpan? sasTtl = null,
         CancellationToken ct = default)
-        => await ExecuteWithExportAsync(
+    {
+        if (options.SplitIntoMultipleFiles)
+        {
+            return await ExecuteMultipleFileExportsAsync(data, columns, baseFileName, options, sasTtl, ct);
+        }
+
+        var result = await ExecuteSingleExportAsync(
             baseFileName,
+            null,
             options,
             sasTtl,
             stream => _excelService.ExportAsync(data, columns, stream, options, ct),
-            ct);
+            ct,
+            appendFileIndex: false,
+            fileIndex: 1);
+        return new[] { result };
+    }
 
-    public async Task<BlobUploadResult> ExecuteAsync(IAsyncEnumerable<IDataRecord> data,
+    public async Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IAsyncEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,
         ExcelExportOptions options,
         TimeSpan? sasTtl = null,
         CancellationToken ct = default)
-        => await ExecuteWithExportAsync(
+    {
+        if (options.SplitIntoMultipleFiles)
+        {
+            return await ExecuteMultipleFileExportsAsync(data, columns, baseFileName, options, sasTtl, ct);
+        }
+
+        var result = await ExecuteSingleExportAsync(
             baseFileName,
+            null,
             options,
             sasTtl,
             stream => _excelService.ExportAsync(data, columns, stream, options, ct),
-            ct);
+            ct,
+            appendFileIndex: false,
+            fileIndex: 1);
+        return new[] { result };
+    }
 
-    private async Task<BlobUploadResult> ExecuteWithExportAsync(
+    private async Task<IReadOnlyList<BlobUploadResult>> ExecuteMultipleFileExportsAsync(
+        IEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,
         ExcelExportOptions options,
         TimeSpan? sasTtl,
-        Func<Stream, Task<ServiceResponse<Stream>>> export,
         CancellationToken ct)
     {
-        var created = DateTime.UtcNow;
-        var dataDate = options.DataDateUtc ?? created.Date;
-        var nameResponse = _namingService.ComposeExcelFileName(baseFileName, dataDate, created);
-        if (!nameResponse.IsSuccess || nameResponse.Data is null)
-            throw new InvalidOperationException(nameResponse.ErrorMessage ?? "File name generation failed");
-        var fileName = nameResponse.Data;
+        using var enumerator = data.GetEnumerator();
+        var bufferedEnumerator = new BufferedRecordEnumerator(enumerator);
+        var exports = new List<BlobUploadResult>();
+        var fileIndex = 1;
+        var (dataDate, created) = ResolveDates(options);
+        var baseGeneratedName = BuildBaseFileName(baseFileName, dataDate, created);
+
+        while (true)
+        {
+            var chunk = TakeNext(bufferedEnumerator, ExcelExportLimits.MaxDataRowsPerSheet, ct);
+            var exportOptions = CloneOptions(options, splitIntoMultipleSheets: false, splitIntoMultipleFiles: false);
+            var exportResponse = await ExportToTempFileAsync(
+                stream => _excelService.ExportAsync(chunk, columns, stream, exportOptions, ct),
+                ct);
+            var hasMore = bufferedEnumerator.TryPeekNext(out _);
+            var appendFileIndex = hasMore || fileIndex > 1;
+            var result = await UploadExportAsync(
+                exportResponse,
+                baseGeneratedName,
+                sasTtl,
+                appendFileIndex,
+                fileIndex,
+                ct);
+            exports.Add(result);
+            fileIndex++;
+            if (!hasMore)
+                break;
+        }
+
+        return exports;
+    }
+
+    private async Task<IReadOnlyList<BlobUploadResult>> ExecuteMultipleFileExportsAsync(
+        IAsyncEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        string baseFileName,
+        ExcelExportOptions options,
+        TimeSpan? sasTtl,
+        CancellationToken ct)
+    {
+        await using var enumerator = data.GetAsyncEnumerator(ct);
+        var bufferedEnumerator = new BufferedAsyncRecordEnumerator(enumerator);
+        var exports = new List<BlobUploadResult>();
+        var fileIndex = 1;
+        var (dataDate, created) = ResolveDates(options);
+        var baseGeneratedName = BuildBaseFileName(baseFileName, dataDate, created);
+
+        while (true)
+        {
+            var chunk = TakeNext(bufferedEnumerator, ExcelExportLimits.MaxDataRowsPerSheet, ct);
+            var exportOptions = CloneOptions(options, splitIntoMultipleSheets: false, splitIntoMultipleFiles: false);
+            var exportResponse = await ExportToTempFileAsync(
+                stream => _excelService.ExportAsync(chunk, columns, stream, exportOptions, ct),
+                ct);
+            var hasMore = await bufferedEnumerator.TryPeekNextAsync();
+            var appendFileIndex = hasMore || fileIndex > 1;
+            var result = await UploadExportAsync(
+                exportResponse,
+                baseGeneratedName,
+                sasTtl,
+                appendFileIndex,
+                fileIndex,
+                ct);
+            exports.Add(result);
+            fileIndex++;
+            if (!hasMore)
+                break;
+        }
+
+        return exports;
+    }
+
+    private async Task<BlobUploadResult> ExecuteSingleExportAsync(
+        string baseFileName,
+        string? baseGeneratedName,
+        ExcelExportOptions options,
+        TimeSpan? sasTtl,
+        Func<Stream, Task<ServiceResponse<Stream>>> export,
+        CancellationToken ct,
+        bool appendFileIndex,
+        int fileIndex)
+    {
+        var (dataDate, created) = ResolveDates(options);
+        var fileNameBase = baseGeneratedName ?? BuildBaseFileName(baseFileName, dataDate, created);
+        var fileName = appendFileIndex
+            ? AppendFileIndex(fileNameBase, fileIndex)
+            : fileNameBase;
         var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
 
         var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -74,16 +179,225 @@ public class ExportExcel : IExportExcel
                 if (!exportResponse.IsSuccess)
                     throw new InvalidOperationException(exportResponse.ErrorMessage ?? "Excel export failed");
                 fs.Position = 0;
-                var response = await _blobRepository.UploadExcelAsync(fs, blobName, sasTtl, ct);
-                if (!response.IsSuccess || response.Data is null)
-                    throw new InvalidOperationException(response.ErrorMessage ?? "Blob upload failed");
-                return response.Data;
+                return await UploadExportAsync(fs, blobName, sasTtl, ct);
             }
         }
         finally
         {
             if (File.Exists(tempFile))
                 File.Delete(tempFile);
+        }
+    }
+
+    private static IEnumerable<IDataRecord> TakeNext(BufferedRecordEnumerator enumerator, int maxRows, CancellationToken ct)
+    {
+        var written = 0;
+        while (written < maxRows && enumerator.TryGetNext(out var record))
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return record;
+            written++;
+        }
+    }
+
+    private static async IAsyncEnumerable<IDataRecord> TakeNext(BufferedAsyncRecordEnumerator enumerator, int maxRows,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        var written = 0;
+        while (written < maxRows && await enumerator.TryGetNextAsync())
+        {
+            ct.ThrowIfCancellationRequested();
+            var record = enumerator.Current ?? throw new InvalidOperationException("Expected record instance.");
+            yield return record;
+            written++;
+        }
+    }
+
+    private static ExcelExportOptions CloneOptions(ExcelExportOptions options, bool splitIntoMultipleSheets, bool splitIntoMultipleFiles)
+        => new()
+        {
+            SheetName = options.SheetName,
+            Culture = options.Culture,
+            FreezeHeader = options.FreezeHeader,
+            AutoFilter = options.AutoFilter,
+            DataDateUtc = options.DataDateUtc,
+            SplitIntoMultipleSheets = splitIntoMultipleSheets,
+            SplitIntoMultipleFiles = splitIntoMultipleFiles
+        };
+
+    private static string AppendFileIndex(string fileName, int fileIndex)
+    {
+        var extension = Path.GetExtension(fileName);
+        var name = Path.GetFileNameWithoutExtension(fileName);
+        return $"{name}_part{fileIndex:D2}{extension}";
+    }
+
+    private (DateTime dataDate, DateTime created) ResolveDates(ExcelExportOptions options)
+    {
+        var created = DateTime.UtcNow;
+        var dataDate = options.DataDateUtc ?? created.Date;
+        return (dataDate, created);
+    }
+
+    private string BuildBaseFileName(string baseFileName, DateTime dataDate, DateTime created)
+    {
+        var nameResponse = _namingService.ComposeExcelFileName(baseFileName, dataDate, created);
+        if (!nameResponse.IsSuccess || nameResponse.Data is null)
+            throw new InvalidOperationException(nameResponse.ErrorMessage ?? "File name generation failed");
+        return nameResponse.Data;
+    }
+
+    private async Task<FileStream> ExportToTempFileAsync(
+        Func<Stream, Task<ServiceResponse<Stream>>> export,
+        CancellationToken ct)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var fs = new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.SequentialScan);
+        try
+        {
+            var exportResponse = await export(fs);
+            if (!exportResponse.IsSuccess)
+                throw new InvalidOperationException(exportResponse.ErrorMessage ?? "Excel export failed");
+            fs.Position = 0;
+            return fs;
+        }
+        catch
+        {
+            await fs.DisposeAsync();
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+            throw;
+        }
+    }
+
+    private async Task<BlobUploadResult> UploadExportAsync(
+        FileStream stream,
+        string baseGeneratedName,
+        TimeSpan? sasTtl,
+        bool appendFileIndex,
+        int fileIndex,
+        CancellationToken ct)
+    {
+        var fileName = appendFileIndex
+            ? AppendFileIndex(baseGeneratedName, fileIndex)
+            : baseGeneratedName;
+        var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
+        try
+        {
+            return await UploadExportAsync(stream, blobName, sasTtl, ct);
+        }
+        finally
+        {
+            var path = stream.Name;
+            await stream.DisposeAsync();
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    private async Task<BlobUploadResult> UploadExportAsync(
+        Stream stream,
+        string blobName,
+        TimeSpan? sasTtl,
+        CancellationToken ct)
+    {
+        var response = await _blobRepository.UploadExcelAsync(stream, blobName, sasTtl, ct);
+        if (!response.IsSuccess || response.Data is null)
+            throw new InvalidOperationException(response.ErrorMessage ?? "Blob upload failed");
+        return response.Data;
+    }
+
+    private sealed class BufferedRecordEnumerator
+    {
+        private readonly IEnumerator<IDataRecord> _inner;
+        private bool _hasBuffered;
+        private IDataRecord? _buffered;
+
+        public BufferedRecordEnumerator(IEnumerator<IDataRecord> inner)
+            => _inner = inner;
+
+        public bool TryGetNext(out IDataRecord record)
+        {
+            if (_hasBuffered)
+            {
+                record = _buffered ?? throw new InvalidOperationException("Buffered record expected.");
+                _buffered = null;
+                _hasBuffered = false;
+                return true;
+            }
+
+            if (_inner.MoveNext())
+            {
+                record = _inner.Current;
+                return true;
+            }
+
+            record = null!;
+            return false;
+        }
+
+        public bool TryPeekNext(out IDataRecord? record)
+        {
+            if (_hasBuffered)
+            {
+                record = _buffered;
+                return true;
+            }
+
+            if (_inner.MoveNext())
+            {
+                _buffered = _inner.Current;
+                _hasBuffered = true;
+                record = _buffered;
+                return true;
+            }
+
+            record = null;
+            return false;
+        }
+    }
+
+    private sealed class BufferedAsyncRecordEnumerator
+    {
+        private readonly IAsyncEnumerator<IDataRecord> _inner;
+        private bool _hasBuffered;
+        public IDataRecord? Current { get; private set; }
+
+        public BufferedAsyncRecordEnumerator(IAsyncEnumerator<IDataRecord> inner)
+            => _inner = inner;
+
+        public async Task<bool> TryGetNextAsync()
+        {
+            if (_hasBuffered)
+            {
+                _hasBuffered = false;
+                return true;
+            }
+
+            if (await _inner.MoveNextAsync())
+            {
+                Current = _inner.Current;
+                return true;
+            }
+
+            Current = null;
+            return false;
+        }
+
+        public async Task<bool> TryPeekNextAsync()
+        {
+            if (_hasBuffered)
+                return true;
+
+            if (await _inner.MoveNextAsync())
+            {
+                Current = _inner.Current;
+                _hasBuffered = true;
+                return true;
+            }
+
+            Current = null;
+            return false;
         }
     }
 

--- a/DataToExcel/Application/Interfaces/IExportExcel.cs
+++ b/DataToExcel/Application/Interfaces/IExportExcel.cs
@@ -5,17 +5,17 @@ namespace DataToExcel.Application.Interfaces;
 
 public interface IExportExcel
 {
-    Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
+    Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,
         ExcelExportOptions options,
         TimeSpan? sasTtl = null,
         CancellationToken ct = default);
 
-    Task<BlobUploadResult> ExecuteAsync(IAsyncEnumerable<IDataRecord> data,
-    IReadOnlyList<ColumnDefinition> columns,
-    string baseFileName,
-    ExcelExportOptions options,
-    TimeSpan? sasTtl = null,
-    CancellationToken ct = default);
+    Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IAsyncEnumerable<IDataRecord> data,
+        IReadOnlyList<ColumnDefinition> columns,
+        string baseFileName,
+        ExcelExportOptions options,
+        TimeSpan? sasTtl = null,
+        CancellationToken ct = default);
 }

--- a/DataToExcel/ExcelExportClient.cs
+++ b/DataToExcel/ExcelExportClient.cs
@@ -76,7 +76,7 @@ public class ExcelExportClient : IExportExcel
         return new ExportExcel(export, naming, repo, options);
     }
 
-    public async Task<BlobUploadResult> ExecuteAsync(IEnumerable<IDataRecord> data,
+    public async Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,
         ExcelExportOptions options,
@@ -84,7 +84,7 @@ public class ExcelExportClient : IExportExcel
         CancellationToken ct = default) =>
         await _inner.ExecuteAsync(data, columns, baseFileName, options, sasTtl, ct);
 
-    public async Task<BlobUploadResult> ExecuteAsync(IAsyncEnumerable<IDataRecord> data,
+    public async Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IAsyncEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,
         ExcelExportOptions options,

--- a/DataToExcel/Models/ExcelExportLimits.cs
+++ b/DataToExcel/Models/ExcelExportLimits.cs
@@ -1,0 +1,8 @@
+namespace DataToExcel.Models;
+
+public static class ExcelExportLimits
+{
+    public const int MaxRowsPerSheet = 1_048_576;
+    public const int HeaderRowCount = 1;
+    public const int MaxDataRowsPerSheet = MaxRowsPerSheet - HeaderRowCount;
+}

--- a/DataToExcel/Models/ExcelExportOptions.cs
+++ b/DataToExcel/Models/ExcelExportOptions.cs
@@ -9,4 +9,6 @@ public class ExcelExportOptions
     public bool FreezeHeader { get; set; } = true;
     public bool AutoFilter { get; set; } = true;
     public DateTime? DataDateUtc { get; set; } = DateTime.UtcNow.Date;
+    public bool SplitIntoMultipleSheets { get; set; }
+    public bool SplitIntoMultipleFiles { get; set; }
 }

--- a/DataToExcel/Properties/AssemblyInfo.cs
+++ b/DataToExcel/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DataToExcel.Test")]

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -235,7 +235,7 @@ public class ExcelExportService : IExcelExportService
         CancellationToken ct)
     {
         await using var enumerator = data.GetAsyncEnumerator(ct);
-        var context = new WriteRowsContext(columns, styleMap, maxRows, enforceLimit: true, ct);
+        var context = new WriteRowsContext(columns, styleMap, maxRows, EnforceLimit: true, ct);
         await WriteRowsCoreAsync(writer, context,
             moveNextAsync: () => enumerator.MoveNextAsync().AsTask(),
             current: () => enumerator.Current);
@@ -248,7 +248,7 @@ public class ExcelExportService : IExcelExportService
         int maxRows,
         CancellationToken ct)
     {
-        var context = new WriteRowsContext(columns, styleMap, maxRows, enforceLimit: false, ct);
+        var context = new WriteRowsContext(columns, styleMap, maxRows, EnforceLimit: false, ct);
         await WriteRowsCoreAsync(writer, context,
             moveNextAsync: data.TryGetNextAsync,
             current: () => data.Current);

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -39,7 +39,7 @@ public class ExcelExportService : IExcelExportService
         Stream output,
         ExcelExportOptions options,
         CancellationToken ct)
-        => ExportMultipleSheetsAsyncCore(output, options, async (workbookPart, sheets, styleMap) =>
+        => ExportMultipleSheetsAsyncCore(output, async (workbookPart, sheets, styleMap) =>
         {
             await using var enumerator = data.GetAsyncEnumerator(ct);
             var bufferedEnumerator = new BufferedAsyncRecordEnumerator(enumerator);
@@ -59,7 +59,6 @@ public class ExcelExportService : IExcelExportService
 
     private async Task<ServiceResponse<Stream>> ExportMultipleSheetsAsyncCore(
         Stream output,
-        ExcelExportOptions options,
         Func<WorkbookPart, Sheets, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeSheetsAsync,
         CancellationToken ct)
     {

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -39,7 +39,7 @@ public class ExcelExportService : IExcelExportService
         Stream output,
         ExcelExportOptions options,
         CancellationToken ct)
-        => ExportMultipleSheetsAsyncCore(output, options, ct, async (workbookPart, sheets, styleMap) =>
+        => ExportMultipleSheetsAsyncCore(output, options, async (workbookPart, sheets, styleMap) =>
         {
             await using var enumerator = data.GetAsyncEnumerator(ct);
             var bufferedEnumerator = new BufferedAsyncRecordEnumerator(enumerator);
@@ -55,13 +55,13 @@ public class ExcelExportService : IExcelExportService
                 sheetIndex++;
                 hasMore = await bufferedEnumerator.TryPeekNextAsync();
             } while (hasMore);
-        });
+        }, ct);
 
     private async Task<ServiceResponse<Stream>> ExportMultipleSheetsAsyncCore(
         Stream output,
         ExcelExportOptions options,
-        CancellationToken ct,
-        Func<WorkbookPart, Sheets, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeSheetsAsync)
+        Func<WorkbookPart, Sheets, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeSheetsAsync,
+        CancellationToken ct)
     {
         try
         {

--- a/DataToExcel/Utilities/BufferedRecordEnumerators.cs
+++ b/DataToExcel/Utilities/BufferedRecordEnumerators.cs
@@ -1,0 +1,62 @@
+using System.Data;
+using System.Runtime.CompilerServices;
+
+namespace DataToExcel.Utilities;
+
+internal sealed class BufferedAsyncRecordEnumerator
+{
+    private readonly IAsyncEnumerator<IDataRecord> _inner;
+    private bool _hasBuffered;
+    public IDataRecord? Current { get; private set; }
+
+    public BufferedAsyncRecordEnumerator(IAsyncEnumerator<IDataRecord> inner)
+        => _inner = inner;
+
+    public async Task<bool> TryGetNextAsync()
+    {
+        if (_hasBuffered)
+        {
+            _hasBuffered = false;
+            return true;
+        }
+
+        if (await _inner.MoveNextAsync())
+        {
+            Current = _inner.Current;
+            return true;
+        }
+
+        Current = null;
+        return false;
+    }
+
+    public async Task<bool> TryPeekNextAsync()
+    {
+        if (_hasBuffered)
+            return true;
+
+        if (await _inner.MoveNextAsync())
+        {
+            Current = _inner.Current;
+            _hasBuffered = true;
+            return true;
+        }
+
+        Current = null;
+        return false;
+    }
+}
+
+internal static class AsyncEnumerableHelpers
+{
+    public static async IAsyncEnumerable<IDataRecord> ToAsyncEnumerable(IEnumerable<IDataRecord> data,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        foreach (var record in data)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return record;
+            await Task.Yield();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ services.AddExcelExport(options =>
 var provider = services.BuildServiceProvider();
 var exporter = provider.GetRequiredService<IExportExcel>();
 
-var result = await exporter.ExecuteAsync(
+var results = await exporter.ExecuteAsync(
     data: records,
     columns: columns,
     baseFileName: "Sales",
@@ -35,7 +35,9 @@ var result = await exporter.ExecuteAsync(
         SheetName = "Sales",
         DataDateUtc = new DateTime(2025, 8, 1),
         FreezeHeader = true,
-        AutoFilter = true
+        AutoFilter = true,
+        SplitIntoMultipleSheets = true,
+        SplitIntoMultipleFiles = false
     },
     ct: CancellationToken.None);
 ```
@@ -69,7 +71,7 @@ var client = new ExcelExportClient("<SecureConnectionString>", "reports", blobPr
 // Or using a container URI and optional credential (for RBAC/AAD)
 var client = new ExcelExportClient(new Uri("https://account.blob.core.windows.net/reports"), blobPrefix: "exports/finance");
 
-var result = await client.ExecuteAsync(
+var results = await client.ExecuteAsync(
     data: records,
     columns: columns,
     baseFileName: "Sales",
@@ -77,7 +79,7 @@ var result = await client.ExecuteAsync(
     ct: CancellationToken.None);
 ```
 
-The `ExecuteAsync` method returns a `BlobUploadResult` with the blob URI, SAS URI, and uploaded size.
+The `ExecuteAsync` method returns a list of `BlobUploadResult` entries (one per generated file) containing the blob URI, SAS URI, and uploaded size.
 
 ## NuGet requirements
 - DocumentFormat.OpenXml
@@ -86,7 +88,7 @@ The `ExecuteAsync` method returns a `BlobUploadResult` with the blob URI, SAS UR
 
 ## Limitations
 - Maximum of 1,048,576 rows per worksheet
-- `IAsyncEnumerable<IDataRecord>` and worksheet splitting are not yet implemented
+- Use `SplitIntoMultipleSheets` to distribute rows across worksheets, or `SplitIntoMultipleFiles` to generate multiple files when row counts exceed the worksheet limit (multiple files take priority).
 
 ## Performance and security notes
 - Uses `OpenXmlWriter` with a temporary `FileStream` to keep memory usage low


### PR DESCRIPTION
### Motivation
- Prevent OpenXML write streams from overflowing Excel's hard worksheet row limit and ensure large exports are safely chunked into additional worksheets or files. 
- Provide deterministic behavior and coverage for the scenario where more than 1,048,576 rows are requested and `SplitIntoMultipleFiles` / `SplitIntoMultipleSheets` should be used. 

### Description
- Added a regression test `GivenSplitIntoMultipleFilesWhenRowLimitExceededThenUploadsMultipleFiles` that simulates `ExcelExportLimits.MaxDataRowsPerSheet + 1` rows and verifies two uploaded parts with `_part01`/`_part02` suffixes. 
- Extended public API to return `Task<IReadOnlyList<BlobUploadResult>>` from `IExportExcel` and `ExcelExportClient`, and updated callers/tests to adapt. 
- Introduced `ExcelExportLimits` constants and `SplitIntoMultipleSheets` / `SplitIntoMultipleFiles` flags on `ExcelExportOptions`, and implemented multi-sheet and multi-file chunking in `ExportExcel` with buffered enumerators (`BufferedRecordEnumerator` / `BufferedAsyncRecordEnumerator`), `ExportToTempFileAsync`, `UploadExportAsync`, and `AppendFileIndex` naming. 
- Enhanced `ExcelExportService` to support splitting into multiple worksheets and to throw a clear `InvalidOperationException` when a non-splitting export would exceed the per-sheet row limit; added sheet-name trimming logic and helpers. 

### Testing
- Ran the test suite with `dotnet test /workspace/DataToExcel/DataToExcel.sln /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:Threshold=80 /p:ThresholdType=line` and all tests passed: `Passed!  - Failed:     0, Passed:    40, Skipped:     0, Total:    40`.
- The newly added test `GivenSplitIntoMultipleFilesWhenRowLimitExceededThenUploadsMultipleFiles` executed and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973efd22bb88320b8ead4aba494bdef)