### PR TITLE
Add configurable header colors for Excel exports

### DIFF
--- a/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
+++ b/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
@@ -1,5 +1,6 @@
 using DataToExcel.Models;
 using DataToExcel.Services;
+using DocumentFormat.OpenXml.Spreadsheet;
 using Xunit;
 
 namespace DataToExcel.Test.Services;
@@ -13,11 +14,71 @@ public class ExcelStyleProviderTests
         var provider = new ExcelStyleProvider();
 
         // When
-        var response = provider.BuildStylesheet(out var map);
+        var response = provider.BuildStylesheet(new ExcelExportOptions(), out var map);
 
         // Then
         Assert.True(response.IsSuccess);
         Assert.NotNull(response.Data);
         Assert.Equal(1u, map[PredefinedStyle.Header]);
+    }
+
+    [Fact]
+    public void GivenHeaderBackgroundColorWhenBuildStylesheetThenHeaderFillShouldBeConfigured()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions { HeaderBackgroundColorHex = "#00FF00" }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        Assert.True(headerFormat.ApplyFill?.Value);
+
+        var headerFill = stylesheet.Fills!.Elements<Fill>().ElementAt((int)headerFormat.FillId!.Value);
+        var patternFill = Assert.IsType<PatternFill>(headerFill.FirstChild);
+        Assert.Equal(PatternValues.Solid, patternFill.PatternType!.Value);
+        Assert.Equal("00FF00", patternFill.ForegroundColor!.Rgb!.Value);
+    }
+
+    [Fact]
+    public void GivenHeaderTextColorWhenBuildStylesheetThenHeaderFontColorShouldBeConfigured()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions { HeaderTextColorHex = "112233" }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Equal("112233", headerFont.GetFirstChild<Color>()!.Rgb!.Value);
+    }
+
+    [Fact]
+    public void GivenInvalidColorsWhenBuildStylesheetThenHeaderStyleShouldFallbackToDefaults()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions
+        {
+            HeaderBackgroundColorHex = "BAD",
+            HeaderTextColorHex = "NOT_A_COLOR"
+        }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        Assert.False(headerFormat.ApplyFill?.Value ?? false);
+
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Null(headerFont.GetFirstChild<Color>());
     }
 }

--- a/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
+++ b/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
@@ -81,4 +81,34 @@ public class ExcelStyleProviderTests
         var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
         Assert.Null(headerFont.GetFirstChild<Color>());
     }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("   ", "\t")]
+    [InlineData("", "NOT_VALID")]
+    [InlineData("BAD", "")]
+    public void GivenBlankOrMixedInvalidHeaderColorsWhenBuildStylesheetThenHeaderStyleShouldFallbackToDefaults(
+        string? backgroundColor,
+        string? textColor)
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions
+        {
+            HeaderBackgroundColorHex = backgroundColor,
+            HeaderTextColorHex = textColor
+        }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        Assert.False(headerFormat.ApplyFill?.Value ?? false);
+
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Null(headerFont.GetFirstChild<Color>());
+    }
 }

--- a/DataToExcel/Models/ExcelExportOptions.cs
+++ b/DataToExcel/Models/ExcelExportOptions.cs
@@ -8,6 +8,8 @@ public class ExcelExportOptions
     public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
     public bool FreezeHeader { get; set; } = true;
     public bool AutoFilter { get; set; } = true;
+    public string? HeaderBackgroundColorHex { get; set; }
+    public string? HeaderTextColorHex { get; set; }
     public DateTime? DataDateUtc { get; set; } = DateTime.UtcNow.Date;
     public bool SplitIntoMultipleSheets { get; set; }
     public bool SplitIntoMultipleFiles { get; set; }

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -55,11 +55,12 @@ public class ExcelExportService : IExcelExportService
                 sheetIndex++;
                 hasMore = await bufferedEnumerator.TryPeekNextAsync();
             } while (hasMore);
-        }, ct);
+        }, options, ct);
 
     private async Task<ServiceResponse<Stream>> ExportMultipleSheetsAsyncCore(
         Stream output,
         Func<WorkbookPart, Sheets, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeSheetsAsync,
+        ExcelExportOptions options,
         CancellationToken ct)
     {
         try
@@ -67,7 +68,7 @@ public class ExcelExportService : IExcelExportService
             if (!output.CanSeek)
                 throw new ArgumentException("Stream must be seekable", nameof(output));
 
-            var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
+            var styleResponse = _styleProvider.BuildStylesheet(options, out var styleMap);
             if (!styleResponse.IsSuccess || styleResponse.Data is null)
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;
@@ -101,7 +102,7 @@ public class ExcelExportService : IExcelExportService
             if (!output.CanSeek)
                 throw new ArgumentException("Stream must be seekable", nameof(output));
 
-            var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
+            var styleResponse = _styleProvider.BuildStylesheet(options, out var styleMap);
             if (!styleResponse.IsSuccess || styleResponse.Data is null)
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;

--- a/DataToExcel/Services/Interfaces/IExcelStyleProvider.cs
+++ b/DataToExcel/Services/Interfaces/IExcelStyleProvider.cs
@@ -5,5 +5,5 @@ namespace DataToExcel.Services.Interfaces;
 
 public interface IExcelStyleProvider
 {
-    ServiceResponse<Stylesheet> BuildStylesheet(out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap);
+    ServiceResponse<Stylesheet> BuildStylesheet(ExcelExportOptions options, out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap);
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ var results = await exporter.ExecuteAsync(
         DataDateUtc = new DateTime(2025, 8, 1),
         FreezeHeader = true,
         AutoFilter = true,
+        HeaderBackgroundColorHex = "#1F4E78",
+        HeaderTextColorHex = "#FFFFFF",
         SplitIntoMultipleSheets = true,
         SplitIntoMultipleFiles = false
     },
@@ -80,6 +82,14 @@ var results = await client.ExecuteAsync(
 ```
 
 The `ExecuteAsync` method returns a list of `BlobUploadResult` entries (one per generated file) containing the blob URI, SAS URI, and uploaded size.
+
+
+## Header style options
+You can customize header styling through `ExcelExportOptions`:
+- `HeaderBackgroundColorHex`: header row background color in HEX (`RRGGBB` or `AARRGGBB`, optional leading `#`).
+- `HeaderTextColorHex`: header text color in HEX (`RRGGBB` or `AARRGGBB`, optional leading `#`).
+
+Invalid color values are ignored and default header style is used.
 
 ## NuGet requirements
 - DocumentFormat.OpenXml


### PR DESCRIPTION
### Motivation
- Permitir que las cabeceras de los archivos Excel sean estilizadas por el consumidor cambiando el color de fondo y el color del texto de la fila de cabeceras.
- Mantener comportamiento por defecto cuando no se proporcionan valores de color válidos y evitar roturas en el flujo de exportación.

### Description
- Añadí dos nuevas opciones a `ExcelExportOptions`: `HeaderBackgroundColorHex` y `HeaderTextColorHex` para aceptar colores en formato HEX (`RRGGBB` o `AARRGGBB`, con `#` opcional). 
- Cambié la firma de `IExcelStyleProvider.BuildStylesheet` para recibir `ExcelExportOptions` y adapté `ExcelExportService` para pasar `options` al construir la hoja de estilos. 
- Implementé en `ExcelStyleProvider` la aplicación del color de texto de cabecera y del relleno sólido de fondo de cabecera, además de la función `NormalizeHexColor` que valida/normaliza los hex y hace fallback silencioso ante valores inválidos. 
- Añadí tests unitarios en `DataToExcel.Test/Services/ExcelStyleProviderTests.cs` que verifican el mapeo de estilo de cabecera, la configuración del relleno de fondo, la configuración del color de texto y el comportamiento ante colores inválidos, y actualicé la documentación en `README.md` con ejemplos de uso.

### Testing
- Ejecuté la suite de tests con `dotnet test DataToExcel.sln` y todos los tests pasaron (`Passed: 48, Failed: 0`).
- Se añadieron y ejecutaron tests específicos en `ExcelStyleProviderTests` que validan: `HeaderBackgroundColor` aplicado, `HeaderTextColor` aplicado y fallback en colores inválidos, y éstos pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35101a1bc8320ad6660ac22b2f8ea)