### PR TITLE
Add header color customization to Excel export and style provider

### DIFF
--- a/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
+++ b/DataToExcel.Test/Services/ExcelStyleProviderTests.cs
@@ -1,5 +1,6 @@
 using DataToExcel.Models;
 using DataToExcel.Services;
+using DocumentFormat.OpenXml.Spreadsheet;
 using Xunit;
 
 namespace DataToExcel.Test.Services;
@@ -13,11 +14,128 @@ public class ExcelStyleProviderTests
         var provider = new ExcelStyleProvider();
 
         // When
-        var response = provider.BuildStylesheet(out var map);
+        var response = provider.BuildStylesheet(new ExcelExportOptions(), out var map);
 
         // Then
         Assert.True(response.IsSuccess);
         Assert.NotNull(response.Data);
         Assert.Equal(1u, map[PredefinedStyle.Header]);
+    }
+
+    [Fact]
+    public void GivenHeaderBackgroundColorWhenBuildStylesheetThenHeaderFillShouldBeConfigured()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions { HeaderBackgroundColorHex = "#00FF00" }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        Assert.True(headerFormat.ApplyFill?.Value);
+
+        var headerFill = stylesheet.Fills!.Elements<Fill>().ElementAt((int)headerFormat.FillId!.Value);
+        var patternFill = Assert.IsType<PatternFill>(headerFill.FirstChild);
+        Assert.Equal(PatternValues.Solid, patternFill.PatternType!.Value);
+        Assert.Equal("FF00FF00", patternFill.ForegroundColor!.Rgb!.Value);
+    }
+
+    [Fact]
+    public void GivenHeaderTextColorWhenBuildStylesheetThenHeaderFontColorShouldBeConfigured()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions { HeaderTextColorHex = "112233" }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Equal("FF112233", headerFont.GetFirstChild<Color>()!.Rgb!.Value);
+    }
+
+
+    [Fact]
+    public void GivenHeaderColorsWithAlphaWhenBuildStylesheetThenShouldPreserveProvidedArgb()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions
+        {
+            HeaderBackgroundColorHex = "8000FF00",
+            HeaderTextColorHex = "7F112233"
+        }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        var headerFill = stylesheet.Fills!.Elements<Fill>().ElementAt((int)headerFormat.FillId!.Value);
+        var patternFill = Assert.IsType<PatternFill>(headerFill.FirstChild);
+        Assert.Equal("8000FF00", patternFill.ForegroundColor!.Rgb!.Value);
+
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Equal("7F112233", headerFont.GetFirstChild<Color>()!.Rgb!.Value);
+    }
+
+    [Fact]
+    public void GivenInvalidColorsWhenBuildStylesheetThenHeaderStyleShouldFallbackToDefaults()
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions
+        {
+            HeaderBackgroundColorHex = "BAD",
+            HeaderTextColorHex = "NOT_A_COLOR"
+        }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        Assert.False(headerFormat.ApplyFill?.Value ?? false);
+
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Null(headerFont.GetFirstChild<Color>());
+    }
+
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("   ", "\t")]
+    [InlineData("", "NOT_VALID")]
+    [InlineData("BAD", "")]
+    public void GivenBlankOrMixedInvalidHeaderColorsWhenBuildStylesheetThenHeaderStyleShouldFallbackToDefaults(
+        string? backgroundColor,
+        string? textColor)
+    {
+        // Given
+        var provider = new ExcelStyleProvider();
+
+        // When
+        var response = provider.BuildStylesheet(new ExcelExportOptions
+        {
+            HeaderBackgroundColorHex = backgroundColor,
+            HeaderTextColorHex = textColor
+        }, out _);
+
+        // Then
+        Assert.True(response.IsSuccess);
+        var stylesheet = Assert.IsType<Stylesheet>(response.Data);
+
+        var headerFormat = stylesheet.CellFormats!.Elements<CellFormat>().ElementAt(1);
+        Assert.False(headerFormat.ApplyFill?.Value ?? false);
+
+        var headerFont = stylesheet.Fonts!.Elements<Font>().ElementAt(1);
+        Assert.Null(headerFont.GetFirstChild<Color>());
     }
 }

--- a/DataToExcel/Models/ExcelExportOptions.cs
+++ b/DataToExcel/Models/ExcelExportOptions.cs
@@ -8,6 +8,8 @@ public class ExcelExportOptions
     public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
     public bool FreezeHeader { get; set; } = true;
     public bool AutoFilter { get; set; } = true;
+    public string? HeaderBackgroundColorHex { get; set; }
+    public string? HeaderTextColorHex { get; set; }
     public DateTime? DataDateUtc { get; set; } = DateTime.UtcNow.Date;
     public bool SplitIntoMultipleSheets { get; set; }
     public bool SplitIntoMultipleFiles { get; set; }

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -55,11 +55,12 @@ public class ExcelExportService : IExcelExportService
                 sheetIndex++;
                 hasMore = await bufferedEnumerator.TryPeekNextAsync();
             } while (hasMore);
-        }, ct);
+        }, options, ct);
 
     private async Task<ServiceResponse<Stream>> ExportMultipleSheetsAsyncCore(
         Stream output,
         Func<WorkbookPart, Sheets, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeSheetsAsync,
+        ExcelExportOptions options,
         CancellationToken ct)
     {
         try
@@ -67,7 +68,7 @@ public class ExcelExportService : IExcelExportService
             if (!output.CanSeek)
                 throw new ArgumentException("Stream must be seekable", nameof(output));
 
-            var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
+            var styleResponse = _styleProvider.BuildStylesheet(options, out var styleMap);
             if (!styleResponse.IsSuccess || styleResponse.Data is null)
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;
@@ -101,7 +102,7 @@ public class ExcelExportService : IExcelExportService
             if (!output.CanSeek)
                 throw new ArgumentException("Stream must be seekable", nameof(output));
 
-            var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
+            var styleResponse = _styleProvider.BuildStylesheet(options, out var styleMap);
             if (!styleResponse.IsSuccess || styleResponse.Data is null)
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;

--- a/DataToExcel/Services/ExcelStyleProvider.cs
+++ b/DataToExcel/Services/ExcelStyleProvider.cs
@@ -1,20 +1,27 @@
 using DataToExcel.Models;
 using DataToExcel.Services.Interfaces;
+using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Spreadsheet;
 
 namespace DataToExcel.Services;
 
 public class ExcelStyleProvider : IExcelStyleProvider
 {
-    public ServiceResponse<Stylesheet> BuildStylesheet(out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap)
+    public ServiceResponse<Stylesheet> BuildStylesheet(ExcelExportOptions options, out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap)
     {
         try
         {
             var fonts = new Fonts();
             fonts.AppendChild(new Font());
-            var boldFont = new Font();
-            boldFont.AppendChild(new Bold());
-            fonts.AppendChild(boldFont);
+
+            var headerFont = new Font();
+            headerFont.AppendChild(new Bold());
+            var headerTextColor = NormalizeHexColor(options.HeaderTextColorHex);
+            if (headerTextColor is not null)
+            {
+                headerFont.AppendChild(new Color { Rgb = headerTextColor });
+            }
+            fonts.AppendChild(headerFont);
 
             var fills = new Fills();
             var fillNone = new Fill();
@@ -23,6 +30,21 @@ public class ExcelStyleProvider : IExcelStyleProvider
             var fillGray = new Fill();
             fillGray.AppendChild(new PatternFill { PatternType = PatternValues.Gray125 });
             fills.AppendChild(fillGray);
+
+            uint headerFillId = 0;
+            var headerBackgroundColor = NormalizeHexColor(options.HeaderBackgroundColorHex);
+            if (headerBackgroundColor is not null)
+            {
+                var headerFill = new Fill();
+                headerFill.AppendChild(new PatternFill
+                {
+                    PatternType = PatternValues.Solid,
+                    ForegroundColor = new ForegroundColor { Rgb = headerBackgroundColor },
+                    BackgroundColor = new BackgroundColor { Indexed = 64 }
+                });
+                fills.AppendChild(headerFill);
+                headerFillId = (uint)fills.Count() - 1;
+            }
 
             var borders = new Borders();
             borders.AppendChild(new Border());
@@ -34,7 +56,7 @@ public class ExcelStyleProvider : IExcelStyleProvider
             var cellFormats = new List<CellFormat>
             {
                 new(),                                // 0 default
-                new() { FontId = 1, ApplyFont = true } // 1 header
+                new() { FontId = 1, FillId = headerFillId, ApplyFont = true, ApplyFill = headerBackgroundColor is not null } // 1 header
             };
 
             // number
@@ -105,5 +127,20 @@ public class ExcelStyleProvider : IExcelStyleProvider
             styleIndexMap = new Dictionary<PredefinedStyle, uint>();
             return new ServiceResponse<Stylesheet> { IsSuccess = false, ErrorMessage = ex.Message };
         }
+    }
+
+    private static HexBinaryValue? NormalizeHexColor(string? color)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+            return null;
+
+        var normalized = color.Trim().TrimStart('#').ToUpperInvariant();
+        if (normalized.Length is not 6 and not 8)
+            return null;
+
+        if (!normalized.All(Uri.IsHexDigit))
+            return null;
+
+        return normalized.Length == 6 ? $"FF{normalized}" : normalized;
     }
 }

--- a/DataToExcel/Services/Interfaces/IExcelStyleProvider.cs
+++ b/DataToExcel/Services/Interfaces/IExcelStyleProvider.cs
@@ -5,5 +5,5 @@ namespace DataToExcel.Services.Interfaces;
 
 public interface IExcelStyleProvider
 {
-    ServiceResponse<Stylesheet> BuildStylesheet(out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap);
+    ServiceResponse<Stylesheet> BuildStylesheet(ExcelExportOptions options, out IReadOnlyDictionary<PredefinedStyle, uint> styleIndexMap);
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ var results = await exporter.ExecuteAsync(
         DataDateUtc = new DateTime(2025, 8, 1),
         FreezeHeader = true,
         AutoFilter = true,
+        HeaderBackgroundColorHex = "#1F4E78",
+        HeaderTextColorHex = "#FFFFFF",
         SplitIntoMultipleSheets = true,
         SplitIntoMultipleFiles = false
     },
@@ -80,6 +82,14 @@ var results = await client.ExecuteAsync(
 ```
 
 The `ExecuteAsync` method returns a list of `BlobUploadResult` entries (one per generated file) containing the blob URI, SAS URI, and uploaded size.
+
+
+## Header style options
+You can customize header styling through `ExcelExportOptions`:
+- `HeaderBackgroundColorHex`: header row background color in HEX (`RRGGBB` or `AARRGGBB`, optional leading `#`).
+- `HeaderTextColorHex`: header text color in HEX (`RRGGBB` or `AARRGGBB`, optional leading `#`).
+
+Invalid color values are ignored and default header style is used.
 
 ## NuGet requirements
 - DocumentFormat.OpenXml


### PR DESCRIPTION
### Motivation
- Allow consumers to customize header row background and text colors when exporting spreadsheets.
- Preserve ARGB color values when provided and fallback to default styles when colors are invalid.

### Description
- Add `HeaderBackgroundColorHex` and `HeaderTextColorHex` properties to `ExcelExportOptions` to surface header color settings.
- Change `IExcelStyleProvider.BuildStylesheet` to accept `ExcelExportOptions` and update `ExcelExportService` callers to pass `options` through.
- Implement header font and fill configuration in `ExcelStyleProvider` using a new `NormalizeHexColor` helper that validates and normalizes `RRGGBB` or `AARRGGBB` hex strings.
- Update `README.md` to document the new header style options and add unit tests in `ExcelStyleProviderTests` covering valid colors, ARGB preservation, and invalid/blank fallbacks.

### Testing
- Ran the unit test suite for the project (including the updated `ExcelStyleProviderTests`) with `dotnet test` and all tests passed.
- Verified the new tests exercise header fill and font color behavior, ARGB handling, and fallback behavior for invalid values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35101a1bc8320ad6660ac22b2f8ea)