### PR TITLE
Expose FileGenerationStarted/FileGenerationCompleted events and forward through client

### DIFF
--- a/DataToExcel.Test/Application/ExportExcelTests.cs
+++ b/DataToExcel.Test/Application/ExportExcelTests.cs
@@ -359,12 +359,12 @@ public class ExportExcelTests
 
         useCase.FileGenerationStarted += (_, args) =>
         {
-            timeline.Add($"start:{args.FileIndex}:{args.FileName}");
+            timeline.Add($"start:{args.FileIndex}:{args.BlobName}");
         };
         useCase.FileGenerationCompleted += (_, args) =>
         {
-            timeline.Add($"done:{args.FileIndex}:{args.FileName}");
-            Assert.Equal(args.FileName, args.UploadResult.BlobName);
+            timeline.Add($"done:{args.FileIndex}:{args.BlobName}");
+            Assert.Equal(args.BlobName, args.UploadResult.BlobName);
         };
 
         var results = await useCase.ExecuteAsync(records, columns, "Report", options);
@@ -405,8 +405,8 @@ public class ExportExcelTests
         Assert.NotNull(completed);
         Assert.Equal(1, started!.FileIndex);
         Assert.Equal(1, completed!.FileIndex);
-        Assert.Equal(started.FileName, completed.FileName);
-        Assert.Equal(completed.FileName, completed.UploadResult.BlobName);
+        Assert.Equal(started.BlobName, completed.BlobName);
+        Assert.Equal(completed.BlobName, completed.UploadResult.BlobName);
     }
 
 

--- a/DataToExcel.Test/Application/ExportExcelTests.cs
+++ b/DataToExcel.Test/Application/ExportExcelTests.cs
@@ -338,6 +338,94 @@ public class ExportExcelTests
         Assert.Contains(blobNames, name => name.Contains("_part02", StringComparison.Ordinal));
     }
 
+
+    [Fact]
+    public async Task GivenSplitIntoMultipleFilesWhenExecuteAsyncThenRaisesStartedAndCompletedEventsInOrder()
+    {
+        var records = new LargeRecordEnumerable(ExcelExportLimits.MaxDataRowsPerSheet + 1);
+        var columns = new List<ColumnDefinition> { new("Value", "Value", ColumnDataType.String) };
+        var options = new ExcelExportOptions
+        {
+            SplitIntoMultipleFiles = true,
+            SplitIntoMultipleSheets = true
+        };
+
+        var timeline = new List<string>();
+        var useCase = new ExportExcel(
+            new CountingExcelExportService(),
+            new FileNamingService(),
+            BuildRepositoryMockWithTimeline(timeline).Object,
+            new ExcelExportRegistrationOptions());
+
+        useCase.FileGenerationStarted += (_, args) =>
+        {
+            timeline.Add($"start:{args.FileIndex}:{args.FileName}");
+        };
+        useCase.FileGenerationCompleted += (_, args) =>
+        {
+            timeline.Add($"done:{args.FileIndex}:{args.FileName}");
+            Assert.Equal(args.FileName, args.UploadResult.BlobName);
+        };
+
+        var results = await useCase.ExecuteAsync(records, columns, "Report", options);
+
+        Assert.Equal(2, results.Count);
+        Assert.Collection(timeline,
+            entry => Assert.Matches(@"^start:1:.*_part01\.xlsx$", entry),
+            entry => Assert.Matches(@"^upload:.*_part01\.xlsx$", entry),
+            entry => Assert.Matches(@"^done:1:.*_part01\.xlsx$", entry),
+            entry => Assert.Matches(@"^start:2:.*_part02\.xlsx$", entry),
+            entry => Assert.Matches(@"^upload:.*_part02\.xlsx$", entry),
+            entry => Assert.Matches(@"^done:2:.*_part02\.xlsx$", entry));
+    }
+
+    [Fact]
+    public async Task GivenSingleFileExportWhenExecuteAsyncThenRaisesStartedAndCompletedOnceWithoutErrors()
+    {
+        var records = new LargeRecordEnumerable(10);
+        var columns = new List<ColumnDefinition> { new("Value", "Value", ColumnDataType.String) };
+        var options = new ExcelExportOptions { SplitIntoMultipleFiles = false };
+
+        FileGenerationStartedEventArgs? started = null;
+        FileGenerationCompletedEventArgs? completed = null;
+
+        var useCase = new ExportExcel(
+            new CountingExcelExportService(),
+            new FileNamingService(),
+            BuildRepositoryMockWithTimeline(new List<string>()).Object,
+            new ExcelExportRegistrationOptions());
+
+        useCase.FileGenerationStarted += (_, args) => started = args;
+        useCase.FileGenerationCompleted += (_, args) => completed = args;
+
+        var results = await useCase.ExecuteAsync(records, columns, "Report", options);
+
+        Assert.Single(results);
+        Assert.NotNull(started);
+        Assert.NotNull(completed);
+        Assert.Equal(1, started!.FileIndex);
+        Assert.Equal(1, completed!.FileIndex);
+        Assert.Equal(started.FileName, completed.FileName);
+        Assert.Equal(completed.FileName, completed.UploadResult.BlobName);
+    }
+
+
+
+    private static Mock<DataToExcel.Repositories.Interfaces.IBlobStorageRepository> BuildRepositoryMockWithTimeline(List<string> timeline)
+    {
+        var repoMock = new Mock<DataToExcel.Repositories.Interfaces.IBlobStorageRepository>();
+        repoMock
+            .Setup(r => r.UploadExcelAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream _, string blobName, TimeSpan? __, CancellationToken ___) =>
+            {
+                timeline.Add($"upload:{blobName}");
+                return new RepositoryResponse<BlobUploadResult>(
+                    new BlobUploadResult("test", blobName, new Uri("https://example.com/blob"), new Uri("https://example.com/blob?sas=1"), 0));
+            });
+
+        return repoMock;
+    }
+
     private static (Mock<IBlobContainerClient> containerMock,
         IExportExcel useCase,
         List<IDataRecord> records,

--- a/DataToExcel.Test/ExcelExportClientTests.cs
+++ b/DataToExcel.Test/ExcelExportClientTests.cs
@@ -151,6 +151,57 @@ public class ExcelExportClientTests
         Assert.EndsWith(".xlsx", result.BlobName);
     }
 
+
+    [Fact]
+    public async Task GivenContainerCtorWhenExecuteAsyncThenRaisesForwardedFileGenerationEvents()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+        var reader = table.CreateDataReader();
+        var records = new List<IDataRecord>();
+        while (reader.Read()) records.Add(reader);
+
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+        var options = new ExcelExportOptions { SheetName = "Names" };
+
+        var containerMock = new Mock<IBlobContainerClient>();
+        var blobMock = new Mock<IBlobClient>();
+
+        containerMock.Setup(c => c.Name).Returns("test");
+        containerMock
+            .Setup(c => c.CreateIfNotExistsAsync(PublicAccessType.None, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        containerMock
+            .Setup(c => c.GetBlobClient(It.IsAny<string>()))
+            .Returns(blobMock.Object);
+
+        blobMock.Setup(b => b.CanGenerateSasUri).Returns(true);
+        blobMock.Setup(b => b.Uri).Returns(new Uri("https://example.com/blob"));
+        blobMock
+            .Setup(b => b.GenerateSasUri(It.IsAny<BlobSasBuilder>()))
+            .Returns(new Uri("https://example.com/blob?sas=1"));
+        blobMock
+            .Setup(b => b.UploadAsync(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var client = new DataToExcel.ExcelExportClient(containerMock.Object, TimeSpan.FromMinutes(5));
+
+        FileGenerationStartedEventArgs? started = null;
+        FileGenerationCompletedEventArgs? completed = null;
+        client.FileGenerationStarted += (_, args) => started = args;
+        client.FileGenerationCompleted += (_, args) => completed = args;
+
+        var result = (await client.ExecuteAsync(records, columns, "Report", options)).Single();
+
+        Assert.NotNull(result);
+        Assert.NotNull(started);
+        Assert.NotNull(completed);
+        Assert.Equal(started!.FileName, completed!.FileName);
+        Assert.Equal(1, started.FileIndex);
+        Assert.Equal(1, completed.FileIndex);
+    }
+
     [Fact]
     public async Task GivenContainerCtor_WhenExecuteAsyncAsyncEnumerable_ThenUploadsBlob()
     {

--- a/DataToExcel.Test/ExcelExportClientTests.cs
+++ b/DataToExcel.Test/ExcelExportClientTests.cs
@@ -197,7 +197,7 @@ public class ExcelExportClientTests
         Assert.NotNull(result);
         Assert.NotNull(started);
         Assert.NotNull(completed);
-        Assert.Equal(started!.FileName, completed!.FileName);
+        Assert.Equal(started!.BlobName, completed!.BlobName);
         Assert.Equal(1, started.FileIndex);
         Assert.Equal(1, completed.FileIndex);
     }

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -113,14 +113,15 @@ public class ExportExcel : IExportExcel
             var fileName = appendFileIndex
                 ? AppendFileIndex(baseGeneratedName, fileIndex)
                 : baseGeneratedName;
+            var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
 
-            OnFileGenerationStarted(fileName, fileIndex);
+            OnFileGenerationStarted(blobName, fileIndex);
             var result = await UploadExportAsync(
                 exportResponse,
                 fileName,
                 sasTtl,
                 ct);
-            OnFileGenerationCompleted(fileName, fileIndex, result);
+            OnFileGenerationCompleted(blobName, fileIndex, result);
 
             exports.Add(result);
             fileIndex++;
@@ -142,7 +143,7 @@ public class ExportExcel : IExportExcel
             : fileNameBase;
         var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
 
-        OnFileGenerationStarted(fileName, request.FileIndex);
+        OnFileGenerationStarted(blobName, request.FileIndex);
         var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         try
         {
@@ -153,7 +154,7 @@ public class ExportExcel : IExportExcel
                     throw new InvalidOperationException(exportResponse.ErrorMessage ?? "Excel export failed");
                 fs.Position = 0;
                 var result = await UploadExportAsync(fs, blobName, request.SasTtl, ct);
-                OnFileGenerationCompleted(fileName, request.FileIndex, result);
+                OnFileGenerationCompleted(blobName, request.FileIndex, result);
                 return result;
             }
         }
@@ -164,11 +165,11 @@ public class ExportExcel : IExportExcel
         }
     }
 
-    private void OnFileGenerationStarted(string fileName, int fileIndex)
-        => FileGenerationStarted?.Invoke(this, new FileGenerationStartedEventArgs(fileName, fileIndex));
+    private void OnFileGenerationStarted(string blobName, int fileIndex)
+        => FileGenerationStarted?.Invoke(this, new FileGenerationStartedEventArgs(blobName, fileIndex));
 
-    private void OnFileGenerationCompleted(string fileName, int fileIndex, BlobUploadResult uploadResult)
-        => FileGenerationCompleted?.Invoke(this, new FileGenerationCompletedEventArgs(fileName, fileIndex, uploadResult));
+    private void OnFileGenerationCompleted(string blobName, int fileIndex, BlobUploadResult uploadResult)
+        => FileGenerationCompleted?.Invoke(this, new FileGenerationCompletedEventArgs(blobName, fileIndex, uploadResult));
 
     private sealed record SingleExportRequest(
         string BaseFileName,

--- a/DataToExcel/Application/ExportExcel.cs
+++ b/DataToExcel/Application/ExportExcel.cs
@@ -15,6 +15,9 @@ public class ExportExcel : IExportExcel
     private readonly IBlobStorageRepository _blobRepository;
     private readonly ExcelExportRegistrationOptions _registrationOptions;
 
+    public event EventHandler<FileGenerationStartedEventArgs>? FileGenerationStarted;
+    public event EventHandler<FileGenerationCompletedEventArgs>? FileGenerationCompleted;
+
     public ExportExcel(IExcelExportService excelService,
         IFileNamingService namingService,
         IBlobStorageRepository blobRepository,
@@ -107,13 +110,18 @@ public class ExportExcel : IExportExcel
             var exportResponse = await exportChunkAsync();
             var hasMore = await hasMoreAsync();
             var appendFileIndex = hasMore || fileIndex > 1;
+            var fileName = appendFileIndex
+                ? AppendFileIndex(baseGeneratedName, fileIndex)
+                : baseGeneratedName;
+
+            OnFileGenerationStarted(fileName, fileIndex);
             var result = await UploadExportAsync(
                 exportResponse,
-                baseGeneratedName,
+                fileName,
                 sasTtl,
-                appendFileIndex,
-                fileIndex,
                 ct);
+            OnFileGenerationCompleted(fileName, fileIndex, result);
+
             exports.Add(result);
             fileIndex++;
             if (!hasMore)
@@ -134,6 +142,7 @@ public class ExportExcel : IExportExcel
             : fileNameBase;
         var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
 
+        OnFileGenerationStarted(fileName, request.FileIndex);
         var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         try
         {
@@ -143,7 +152,9 @@ public class ExportExcel : IExportExcel
                 if (!exportResponse.IsSuccess)
                     throw new InvalidOperationException(exportResponse.ErrorMessage ?? "Excel export failed");
                 fs.Position = 0;
-                return await UploadExportAsync(fs, blobName, request.SasTtl, ct);
+                var result = await UploadExportAsync(fs, blobName, request.SasTtl, ct);
+                OnFileGenerationCompleted(fileName, request.FileIndex, result);
+                return result;
             }
         }
         finally
@@ -152,6 +163,12 @@ public class ExportExcel : IExportExcel
                 File.Delete(tempFile);
         }
     }
+
+    private void OnFileGenerationStarted(string fileName, int fileIndex)
+        => FileGenerationStarted?.Invoke(this, new FileGenerationStartedEventArgs(fileName, fileIndex));
+
+    private void OnFileGenerationCompleted(string fileName, int fileIndex, BlobUploadResult uploadResult)
+        => FileGenerationCompleted?.Invoke(this, new FileGenerationCompletedEventArgs(fileName, fileIndex, uploadResult));
 
     private sealed record SingleExportRequest(
         string BaseFileName,
@@ -239,19 +256,14 @@ public class ExportExcel : IExportExcel
 
     private async Task<BlobUploadResult> UploadExportAsync(
         FileStream stream,
-        string baseGeneratedName,
+        string fileName,
         TimeSpan? sasTtl,
-        bool appendFileIndex,
-        int fileIndex,
         CancellationToken ct)
     {
-        var fileName = appendFileIndex
-            ? AppendFileIndex(baseGeneratedName, fileIndex)
-            : baseGeneratedName;
         var blobName = ComposeBlobName(_registrationOptions.BlobPrefix, fileName);
         try
         {
-            return await UploadExportAsync(stream, blobName, sasTtl, ct);
+            return await UploadExportAsync((Stream)stream, blobName, sasTtl, ct);
         }
         finally
         {

--- a/DataToExcel/Application/Interfaces/IExportExcel.cs
+++ b/DataToExcel/Application/Interfaces/IExportExcel.cs
@@ -5,6 +5,9 @@ namespace DataToExcel.Application.Interfaces;
 
 public interface IExportExcel
 {
+    event EventHandler<FileGenerationStartedEventArgs>? FileGenerationStarted;
+    event EventHandler<FileGenerationCompletedEventArgs>? FileGenerationCompleted;
+
     Task<IReadOnlyList<BlobUploadResult>> ExecuteAsync(IEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         string baseFileName,

--- a/DataToExcel/ExcelExportClient.cs
+++ b/DataToExcel/ExcelExportClient.cs
@@ -15,6 +15,9 @@ public class ExcelExportClient : IExportExcel
 {
     private readonly ExportExcel _inner;
 
+    public event EventHandler<FileGenerationStartedEventArgs>? FileGenerationStarted;
+    public event EventHandler<FileGenerationCompletedEventArgs>? FileGenerationCompleted;
+
     public ExcelExportClient(string connectionString, string containerName, TimeSpan? defaultSasTtl = null, string? blobPrefix = null)
     {
         var options = new ExcelExportRegistrationOptions
@@ -25,6 +28,7 @@ public class ExcelExportClient : IExportExcel
             BlobPrefix = blobPrefix
         };
         _inner = Build(options);
+        AttachInnerEvents();
     }
 
     public ExcelExportClient(Uri containerUri, TokenCredential? credential = null, TimeSpan? defaultSasTtl = null, string? blobPrefix = null)
@@ -37,6 +41,7 @@ public class ExcelExportClient : IExportExcel
             BlobPrefix = blobPrefix
         };
         _inner = Build(options);
+        AttachInnerEvents();
     }
 
     public ExcelExportClient(IBlobContainerClient container, TimeSpan? defaultSasTtl = null, string? blobPrefix = null)
@@ -48,6 +53,13 @@ public class ExcelExportClient : IExportExcel
             BlobPrefix = blobPrefix
         };
         _inner = Build(options, container);
+        AttachInnerEvents();
+    }
+
+    private void AttachInnerEvents()
+    {
+        _inner.FileGenerationStarted += (_, args) => FileGenerationStarted?.Invoke(this, args);
+        _inner.FileGenerationCompleted += (_, args) => FileGenerationCompleted?.Invoke(this, args);
     }
 
     private static ExportExcel Build(ExcelExportRegistrationOptions options, IBlobContainerClient? container = null)

--- a/DataToExcel/Models/FileGenerationCompletedEventArgs.cs
+++ b/DataToExcel/Models/FileGenerationCompletedEventArgs.cs
@@ -1,0 +1,15 @@
+namespace DataToExcel.Models;
+
+public sealed class FileGenerationCompletedEventArgs : EventArgs
+{
+    public FileGenerationCompletedEventArgs(string fileName, int fileIndex, BlobUploadResult uploadResult)
+    {
+        FileName = fileName;
+        FileIndex = fileIndex;
+        UploadResult = uploadResult;
+    }
+
+    public string FileName { get; }
+    public int FileIndex { get; }
+    public BlobUploadResult UploadResult { get; }
+}

--- a/DataToExcel/Models/FileGenerationCompletedEventArgs.cs
+++ b/DataToExcel/Models/FileGenerationCompletedEventArgs.cs
@@ -2,14 +2,14 @@ namespace DataToExcel.Models;
 
 public sealed class FileGenerationCompletedEventArgs : EventArgs
 {
-    public FileGenerationCompletedEventArgs(string fileName, int fileIndex, BlobUploadResult uploadResult)
+    public FileGenerationCompletedEventArgs(string blobName, int fileIndex, BlobUploadResult uploadResult)
     {
-        FileName = fileName;
+        BlobName = blobName;
         FileIndex = fileIndex;
         UploadResult = uploadResult;
     }
 
-    public string FileName { get; }
+    public string BlobName { get; }
     public int FileIndex { get; }
     public BlobUploadResult UploadResult { get; }
 }

--- a/DataToExcel/Models/FileGenerationStartedEventArgs.cs
+++ b/DataToExcel/Models/FileGenerationStartedEventArgs.cs
@@ -2,12 +2,12 @@ namespace DataToExcel.Models;
 
 public sealed class FileGenerationStartedEventArgs : EventArgs
 {
-    public FileGenerationStartedEventArgs(string fileName, int fileIndex)
+    public FileGenerationStartedEventArgs(string blobName, int fileIndex)
     {
-        FileName = fileName;
+        BlobName = blobName;
         FileIndex = fileIndex;
     }
 
-    public string FileName { get; }
+    public string BlobName { get; }
     public int FileIndex { get; }
 }

--- a/DataToExcel/Models/FileGenerationStartedEventArgs.cs
+++ b/DataToExcel/Models/FileGenerationStartedEventArgs.cs
@@ -1,0 +1,13 @@
+namespace DataToExcel.Models;
+
+public sealed class FileGenerationStartedEventArgs : EventArgs
+{
+    public FileGenerationStartedEventArgs(string fileName, int fileIndex)
+    {
+        FileName = fileName;
+        FileIndex = fileIndex;
+    }
+
+    public string FileName { get; }
+    public int FileIndex { get; }
+}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ var results = await client.ExecuteAsync(
 
 The `ExecuteAsync` method returns a list of `BlobUploadResult` entries (one per generated file) containing the blob URI, SAS URI, and uploaded size.
 
+### Tracking asynchronous multi-file progress
+When `SplitIntoMultipleFiles = true`, you can subscribe to two events to track generation status:
+
+- `FileGenerationStarted`: fired right before each file is uploaded.
+- `FileGenerationCompleted`: fired after each file is uploaded.
+
+Both events provide the file name and file index (`part01`, `part02`, etc.).
+
+```csharp
+exporter.FileGenerationStarted += (_, e) =>
+{
+    Console.WriteLine($"Starting file {e.FileIndex}: {e.FileName}");
+};
+
+exporter.FileGenerationCompleted += (_, e) =>
+{
+    Console.WriteLine($"Completed file {e.FileIndex}: {e.FileName} ({e.UploadResult.SizeBytes} bytes)");
+};
+```
+
 ## NuGet requirements
 - DocumentFormat.OpenXml
 - Azure.Storage.Blobs

--- a/README.md
+++ b/README.md
@@ -87,17 +87,17 @@ When `SplitIntoMultipleFiles = true`, you can subscribe to two events to track g
 - `FileGenerationStarted`: fired right before each file is uploaded.
 - `FileGenerationCompleted`: fired after each file is uploaded.
 
-Both events provide the file name and file index (`part01`, `part02`, etc.).
+Both events provide the full `BlobName` (including prefix/path) and the file index (`part01`, `part02`, etc.).
 
 ```csharp
 exporter.FileGenerationStarted += (_, e) =>
 {
-    Console.WriteLine($"Starting file {e.FileIndex}: {e.FileName}");
+    Console.WriteLine($"Starting file {e.FileIndex}: {e.BlobName}");
 };
 
 exporter.FileGenerationCompleted += (_, e) =>
 {
-    Console.WriteLine($"Completed file {e.FileIndex}: {e.FileName} ({e.UploadResult.SizeBytes} bytes)");
+    Console.WriteLine($"Completed file {e.FileIndex}: {e.BlobName} ({e.UploadResult.SizeBytes} bytes)");
 };
 ```
 


### PR DESCRIPTION
### Motivation

- Provide progress hooks so callers can track per-file generation and upload when exports are split across multiple files.

### Description

- Added `FileGenerationStarted` and `FileGenerationCompleted` events to `IExportExcel` and implemented them in `ExportExcel` with `OnFileGenerationStarted` and `OnFileGenerationCompleted` helpers.
- Fire the events for both single-file and multi-file export paths, and refactored internal file naming to compute the final `fileName` prior to uploading so the events can carry the exact name and index.
- Introduced `FileGenerationStartedEventArgs` and `FileGenerationCompletedEventArgs` models to carry `FileName`, `FileIndex`, and `UploadResult` information.
- Updated `ExcelExportClient` to attach and forward the inner `ExportExcel` events so consumers using the standalone client receive the same notifications.
- Added unit tests to verify event ordering and forwarding (`GivenSplitIntoMultipleFilesWhenExecuteAsyncThenRaisesStartedAndCompletedEventsInOrder`, `GivenSingleFileExportWhenExecuteAsyncThenRaisesStartedAndCompletedOnceWithoutErrors`, and `GivenContainerCtorWhenExecuteAsyncThenRaisesForwardedFileGenerationEvents`) and helper `BuildRepositoryMockWithTimeline` used by the tests.
- Documented the new events and usage in `README.md` under "Tracking asynchronous multi-file progress".

### Testing

- Ran unit tests in `DataToExcel.Test`, including the new tests in `ExportExcelTests` and `ExcelExportClientTests`, and they passed successfully.
- Existing blob upload and naming-related tests were executed and continued to pass after the changes.
- New tests verify event firing order, file name/index values, and that the client forwards events correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1eabbebb883209806e238d9c10809)