### PR TITLE
Support non-seekable output streams, use ordinals for IDataRecord access, and improve sheet naming/cell handling

### DIFF
--- a/DataToExcel.Test/Integration/IntegrationTests.cs
+++ b/DataToExcel.Test/Integration/IntegrationTests.cs
@@ -7,6 +7,7 @@ using DataToExcel.Hosting;
 using DataToExcel.Models;
 using DataToExcel.Repositories;
 using DataToExcel.Repositories.Interfaces;
+using DataToExcel.Services;
 using DataToExcel.Wrappers.Interfaces;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -18,6 +19,10 @@ namespace DataToExcel.Test.Integration;
 
 public class IntegrationTests
 {
+    private const int LargeExportRowCount = 800_000;
+    private const long LargeExportMaxManagedMemoryGrowthBytes = 1536L * 1024 * 1024;
+    private const long ReleasedMemoryMaxRetainedGrowthBytes = 16L * 1024 * 1024;
+
     [Fact]
     public async Task GivenMockedBlobStorageWhenUseCaseExecutesViaDIThenBlobShouldBeUploaded()
     {
@@ -208,6 +213,71 @@ public class IntegrationTests
         });
     }
 
+    [Fact]
+    public async Task GivenLargeStreamingExportWhenFileIsGeneratedThenManagedMemoryGrowthStaysBounded()
+    {
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        var columns = BuildLargeExportColumns();
+        var options = new ExcelExportOptions { SheetName = "LargeExport" };
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        await ForceFullCollectionAsync();
+        var baseline = GC.GetTotalMemory(forceFullCollection: true);
+
+        try
+        {
+            await using var stream = new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None);
+            var result = await MeasureManagedMemoryDuringAsync(async () =>
+                await service.ExportAsync(new LargeStreamingRecords(LargeExportRowCount), columns, stream, options));
+
+            Assert.True(result.Response.IsSuccess, result.Response.ErrorMessage);
+            Assert.True(stream.Length > 0);
+            Assert.True(result.PeakBytes - baseline < LargeExportMaxManagedMemoryGrowthBytes,
+                $"Managed memory growth was {(result.PeakBytes - baseline) / 1024 / 1024} MB.");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task GivenLargeStreamingExportWhenReferencesAreReleasedThenManagedMemoryIsReclaimed()
+    {
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        var columns = BuildLargeExportColumns();
+        var options = new ExcelExportOptions { SheetName = "LargeExport" };
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        await ForceFullCollectionAsync();
+        var baseline = GC.GetTotalMemory(forceFullCollection: true);
+
+        try
+        {
+            await using (var stream = new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                var response = await service.ExportAsync(new LargeStreamingRecords(LargeExportRowCount), columns, stream, options);
+                Assert.True(response.IsSuccess, response.ErrorMessage);
+                Assert.True(stream.Length > 0);
+            }
+
+            service = null!;
+            columns = null!;
+            options = null!;
+            await ForceFullCollectionAsync();
+
+            var retainedGrowth = GC.GetTotalMemory(forceFullCollection: true) - baseline;
+            Assert.True(retainedGrowth < ReleasedMemoryMaxRetainedGrowthBytes,
+                $"Retained managed memory growth was {retainedGrowth / 1024 / 1024} MB.");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
     private static DataTable BuildGroupedTable()
     {
         var table = new DataTable();
@@ -224,6 +294,77 @@ public class IntegrationTests
         }
 
         return table;
+    }
+
+    private static IReadOnlyList<ColumnDefinition> BuildLargeExportColumns()
+        => new List<ColumnDefinition>
+        {
+            new("Id", "Id", ColumnDataType.Number),
+            new("Name", "Name", ColumnDataType.String),
+            new("Amount", "Amount", ColumnDataType.Number),
+            new("CreatedOn", "CreatedOn", ColumnDataType.DateTime),
+            new("IsActive", "IsActive", ColumnDataType.Boolean),
+            new("Region", "Region", ColumnDataType.String),
+            new("Status", "Status", ColumnDataType.String),
+            new("Category", "Category", ColumnDataType.String),
+            new("Subcategory", "Subcategory", ColumnDataType.String),
+            new("Quantity", "Quantity", ColumnDataType.Number),
+            new("UnitPrice", "UnitPrice", ColumnDataType.Number),
+            new("Discount", "Discount", ColumnDataType.Number),
+            new("Tax", "Tax", ColumnDataType.Number),
+            new("Total", "Total", ColumnDataType.Number),
+            new("CreatedBy", "CreatedBy", ColumnDataType.String),
+            new("UpdatedOn", "UpdatedOn", ColumnDataType.DateTime),
+            new("UpdatedBy", "UpdatedBy", ColumnDataType.String),
+            new("ExternalId", "ExternalId", ColumnDataType.String),
+            new("Currency", "Currency", ColumnDataType.String),
+            new("Country", "Country", ColumnDataType.String),
+            new("Channel", "Channel", ColumnDataType.String),
+            new("Priority", "Priority", ColumnDataType.Number),
+            new("Score", "Score", ColumnDataType.Number),
+            new("Reviewed", "Reviewed", ColumnDataType.Boolean),
+            new("Notes", "Notes", ColumnDataType.String)
+        };
+
+    private static async Task<(ServiceResponse<Stream> Response, long PeakBytes)> MeasureManagedMemoryDuringAsync(
+        Func<Task<ServiceResponse<Stream>>> exportAsync)
+    {
+        var peakBytes = GC.GetTotalMemory(forceFullCollection: false);
+        using var cts = new CancellationTokenSource();
+        var sampler = Task.Run(async () =>
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                peakBytes = Math.Max(peakBytes, GC.GetTotalMemory(forceFullCollection: false));
+                await Task.Delay(25, cts.Token).ConfigureAwait(false);
+            }
+        });
+
+        try
+        {
+            var response = await exportAsync();
+            peakBytes = Math.Max(peakBytes, GC.GetTotalMemory(forceFullCollection: false));
+            return (response, peakBytes);
+        }
+        finally
+        {
+            await cts.CancelAsync();
+            try
+            {
+                await sampler;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private static async Task ForceFullCollectionAsync()
+    {
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
+        await Task.Yield();
     }
 
     private static IEnumerable<IDataRecord> ToRecords(DataTable table)
@@ -276,5 +417,168 @@ public class IntegrationTests
 
             return new ValueTask<bool>(_reader.Read());
         }
+    }
+
+    private sealed class LargeStreamingRecords : IAsyncEnumerable<IDataRecord>, IAsyncEnumerator<IDataRecord>
+    {
+        private readonly int _count;
+        private readonly LargeStreamingRecord _record = new();
+        private int _current;
+
+        public LargeStreamingRecords(int count)
+            => _count = count;
+
+        public IDataRecord Current => _record;
+
+        public IAsyncEnumerator<IDataRecord> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => this;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+
+        public ValueTask<bool> MoveNextAsync()
+        {
+            if (_current >= _count)
+                return new ValueTask<bool>(false);
+
+            _current++;
+            _record.SetRow(_current);
+            return new ValueTask<bool>(true);
+        }
+    }
+
+    private sealed class LargeStreamingRecord : IDataRecord
+    {
+        private static readonly string[] Names =
+        [
+            "Id", "Name", "Amount", "CreatedOn", "IsActive",
+            "Region", "Status", "Category", "Subcategory", "Quantity",
+            "UnitPrice", "Discount", "Tax", "Total", "CreatedBy",
+            "UpdatedOn", "UpdatedBy", "ExternalId", "Currency", "Country",
+            "Channel", "Priority", "Score", "Reviewed", "Notes"
+        ];
+
+        private static readonly string[] CustomerNames = Enumerable.Range(0, 1_024)
+            .Select(i => $"Customer {i:D4}")
+            .ToArray();
+
+        private static readonly string[] ExternalIds = Enumerable.Range(0, 1_024)
+            .Select(i => $"EXT-{i:D8}")
+            .ToArray();
+
+        private static readonly string[] Notes = Enumerable.Range(0, 1_024)
+            .Select(i => $"Generated note {i:D4}")
+            .ToArray();
+
+        private static readonly string[] Regions = Enumerable.Range(0, 8)
+            .Select(i => $"Region {i}")
+            .ToArray();
+
+        private static readonly string[] Categories = Enumerable.Range(0, 12)
+            .Select(i => $"Category {i}")
+            .ToArray();
+
+        private static readonly string[] Subcategories = Enumerable.Range(0, 24)
+            .Select(i => $"Subcategory {i}")
+            .ToArray();
+
+        private static readonly string[] CreatedByUsers = Enumerable.Range(0, 50)
+            .Select(i => $"User {i}")
+            .ToArray();
+
+        private static readonly string[] UpdatedByUsers = Enumerable.Range(0, 25)
+            .Select(i => $"Updater {i}")
+            .ToArray();
+
+        private int _row;
+
+        public int FieldCount => Names.Length;
+        public object this[int i] => GetValue(i);
+        public object this[string name] => GetValue(GetOrdinal(name));
+
+        public void SetRow(int row)
+            => _row = row;
+
+        public bool GetBoolean(int i) => _row % 2 == 0;
+        public byte GetByte(int i) => (byte)(_row % byte.MaxValue);
+        public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => 0;
+        public char GetChar(int i) => 'A';
+        public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => 0;
+        public IDataReader GetData(int i) => throw new NotSupportedException();
+        public string GetDataTypeName(int i) => GetFieldType(i).Name;
+        public DateTime GetDateTime(int i) => new(2026, 1, 1);
+        public decimal GetDecimal(int i) => _row / 10m;
+        public double GetDouble(int i) => _row / 10d;
+        public Type GetFieldType(int i)
+            => i switch
+            {
+                0 => typeof(int),
+                2 => typeof(decimal),
+                3 => typeof(DateTime),
+                4 => typeof(bool),
+                9 => typeof(int),
+                10 => typeof(decimal),
+                11 => typeof(decimal),
+                12 => typeof(decimal),
+                13 => typeof(decimal),
+                15 => typeof(DateTime),
+                21 => typeof(int),
+                22 => typeof(decimal),
+                23 => typeof(bool),
+                _ => typeof(string)
+            };
+
+        public float GetFloat(int i) => _row / 10f;
+        public Guid GetGuid(int i) => Guid.Empty;
+        public short GetInt16(int i) => (short)_row;
+        public int GetInt32(int i) => _row;
+        public long GetInt64(int i) => _row;
+        public string GetName(int i) => Names[i];
+        public int GetOrdinal(string name) => Array.IndexOf(Names, name);
+        public string GetString(int i) => CustomerNames[_row % CustomerNames.Length];
+
+        public object GetValue(int i)
+            => i switch
+            {
+                0 => _row,
+                1 => GetString(i),
+                2 => GetDecimal(i),
+                3 => GetDateTime(i),
+                4 => GetBoolean(i),
+                5 => Regions[_row % Regions.Length],
+                6 => _row % 3 == 0 ? "Closed" : "Open",
+                7 => Categories[_row % Categories.Length],
+                8 => Subcategories[_row % Subcategories.Length],
+                9 => _row % 100,
+                10 => _row / 100m,
+                11 => (_row % 15) / 100m,
+                12 => (_row % 20) / 100m,
+                13 => _row * 1.13m,
+                14 => CreatedByUsers[_row % CreatedByUsers.Length],
+                15 => GetDateTime(i).AddDays(_row % 30),
+                16 => UpdatedByUsers[_row % UpdatedByUsers.Length],
+                17 => ExternalIds[_row % ExternalIds.Length],
+                18 => _row % 2 == 0 ? "USD" : "CAD",
+                19 => _row % 2 == 0 ? "US" : "CA",
+                20 => _row % 3 == 0 ? "Online" : "Retail",
+                21 => _row % 5,
+                22 => (_row % 1000) / 10m,
+                23 => _row % 4 == 0,
+                24 => Notes[_row % Notes.Length],
+                _ => throw new IndexOutOfRangeException()
+            };
+
+        public int GetValues(object[] values)
+        {
+            var count = Math.Min(values.Length, FieldCount);
+            for (var i = 0; i < count; i++)
+            {
+                values[i] = GetValue(i);
+            }
+
+            return count;
+        }
+
+        public bool IsDBNull(int i) => false;
     }
 }

--- a/DataToExcel.Test/Services/ExcelExportServiceTests.cs
+++ b/DataToExcel.Test/Services/ExcelExportServiceTests.cs
@@ -462,6 +462,78 @@ public class ExcelExportServiceTests
         Assert.Equal("Alice", dataCells[1].InnerText);
     }
 
+
+    [Fact]
+    public async Task GivenCaseMismatchedFieldNamesWhenExportAsyncThenValuesAreResolvedCaseInsensitive()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Columns.Add("Age", typeof(int));
+        table.Rows.Add("Alice", 30);
+        var records = ToAsyncEnumerable(table);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("name","name", ColumnDataType.String),
+            new("age","age", ColumnDataType.Number)
+        };
+
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var rows = doc.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+        var dataCells = rows[1].Elements<Cell>().ToList();
+        Assert.Equal("Alice", dataCells[0].InnerText);
+        Assert.Equal("30", dataCells[1].CellValue!.Text);
+    }
+
+    [Fact]
+    public async Task GivenLongSheetNameWithoutSplitWhenExportAsyncThenSheetNameIsTrimmedTo31Chars()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+        var options = new ExcelExportOptions { SheetName = new string('X', 40), SplitIntoMultipleSheets = false };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(ToAsyncEnumerable(table), columns, ms, options);
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var sheet = doc.WorkbookPart!.Workbook.Sheets!.Elements<Sheet>().First();
+        Assert.Equal(31, sheet.Name!.Value!.Length);
+        Assert.Equal(new string('X', 31), sheet.Name!.Value);
+    }
+
+    [Fact]
+    public async Task GivenNonSeekableOutputWhenExportAsyncThenWorkbookIsWrittenUsingStaging()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add("Alice");
+
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        var columns = new List<ColumnDefinition> { new("Name", "Name", ColumnDataType.String) };
+        using var nonSeekable = new NonSeekableWriteOnlyStream();
+
+        var response = await service.ExportAsync(ToAsyncEnumerable(table), columns, nonSeekable, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        var bytes = nonSeekable.ToArray();
+        using var resultStream = new MemoryStream(bytes);
+        using var doc = SpreadsheetDocument.Open(resultStream, false);
+        var dataRows = doc.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+        Assert.Equal("Alice", dataRows[1].Elements<Cell>().First().InnerText);
+    }
+
     private static DataTable BuildGroupedTable(bool withItem = false)
     {
         var table = new DataTable();
@@ -601,4 +673,31 @@ public class ExcelExportServiceTests
             return new ForwardOnlyAsyncRecords(table);
         }
     }
+
+    private sealed class NonSeekableWriteOnlyStream : Stream
+    {
+        private readonly MemoryStream _inner = new();
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => _inner.Length;
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => _inner.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => _inner.WriteAsync(buffer, cancellationToken);
+
+        public byte[] ToArray() => _inner.ToArray();
+    }
+
 }

--- a/DataToExcel.Test/Services/ExcelExportServiceTests.cs
+++ b/DataToExcel.Test/Services/ExcelExportServiceTests.cs
@@ -312,6 +312,40 @@ public class ExcelExportServiceTests
     }
 
     [Fact]
+    public async Task GivenFirstGroupedValueIsNullWhenExportAsyncThenFirstRowStartsGroup()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("Amount", typeof(int));
+        table.Rows.Add(DBNull.Value, 10);
+        table.Rows.Add(DBNull.Value, 20);
+        table.Rows.Add("A", 30);
+        var records = ToAsyncEnumerable(table);
+
+        var columns = new List<ColumnDefinition>
+        {
+            new("Category", "Category", ColumnDataType.String, Group: true),
+            new("Amount", "Amount", ColumnDataType.Number)
+        };
+        var service = new ExcelExportService(new ExcelStyleProvider());
+        using var ms = new MemoryStream();
+
+        var response = await service.ExportAsync(records, columns, ms, new ExcelExportOptions());
+
+        Assert.True(response.IsSuccess);
+        ms.Position = 0;
+        using var doc = SpreadsheetDocument.Open(ms, false);
+        var rows = doc.WorkbookPart!.WorksheetParts.First().Worksheet.GetFirstChild<SheetData>()!.Elements<Row>().ToList();
+
+        Assert.Null(rows[1].OutlineLevel);
+        Assert.Equal(string.Empty, rows[1].Elements<Cell>().First().InnerText);
+        Assert.Equal("10", rows[1].Elements<Cell>().Last().CellValue!.Text);
+        Assert.Equal((byte)1, rows[2].OutlineLevel!.Value);
+        Assert.Null(rows[3].OutlineLevel);
+        Assert.Equal("A", rows[3].Elements<Cell>().First().InnerText);
+    }
+
+    [Fact]
     public async Task GivenGroupedMiddleColumnWhenExportAsyncThenRowsShouldBeGrouped()
     {
         var table = BuildGroupedTable(withItem: true);

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -57,6 +57,51 @@ public class ExcelExportService : IExcelExportService
             } while (hasMore);
         }, ct);
 
+
+    private static async Task<ServiceResponse<Stream>> ExportUsingSeekableStreamAsync(
+        Stream output,
+        Func<Stream, Task> exportToSeekableStreamAsync,
+        CancellationToken ct)
+    {
+        var needsStaging = !output.CanSeek;
+        var seekableStream = needsStaging ? CreateTempFileStream() : output;
+
+        try
+        {
+            await exportToSeekableStreamAsync(seekableStream);
+
+            if (needsStaging)
+            {
+                seekableStream.Position = 0;
+                await seekableStream.CopyToAsync(output, 81920, ct);
+                await output.FlushAsync(ct);
+            }
+            else
+            {
+                await output.FlushAsync(ct);
+            }
+
+            return new ServiceResponse<Stream>(output) { IsSuccess = true };
+        }
+        finally
+        {
+            if (needsStaging)
+            {
+                var tempName = (seekableStream as FileStream)?.Name;
+                await seekableStream.DisposeAsync();
+                if (!string.IsNullOrWhiteSpace(tempName) && File.Exists(tempName))
+                    File.Delete(tempName);
+            }
+        }
+    }
+
+    private static FileStream CreateTempFileStream()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        return new FileStream(tempFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 4096,
+            FileOptions.Asynchronous | FileOptions.SequentialScan | FileOptions.DeleteOnClose);
+    }
+
     private async Task<ServiceResponse<Stream>> ExportMultipleSheetsAsyncCore(
         Stream output,
         Func<WorkbookPart, Sheets, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeSheetsAsync,
@@ -64,26 +109,23 @@ public class ExcelExportService : IExcelExportService
     {
         try
         {
-            if (!output.CanSeek)
-                throw new ArgumentException("Stream must be seekable", nameof(output));
-
             var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
             if (!styleResponse.IsSuccess || styleResponse.Data is null)
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;
 
-            using var document = SpreadsheetDocument.Create(output, SpreadsheetDocumentType.Workbook, true);
-            var workbookPart = document.AddWorkbookPart();
-            workbookPart.Workbook = new Workbook();
-            var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-            stylesPart.Stylesheet = stylesheet;
-            var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+            return await ExportUsingSeekableStreamAsync(output, async seekableStream =>
+            {
+                using var document = SpreadsheetDocument.Create(seekableStream, SpreadsheetDocumentType.Workbook, true);
+                var workbookPart = document.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+                var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet = stylesheet;
+                var sheets = workbookPart.Workbook.AppendChild(new Sheets());
 
-            await writeSheetsAsync(workbookPart, sheets, styleMap);
-
-            workbookPart.Workbook.Save();
-            await output.FlushAsync(ct);
-            return new ServiceResponse<Stream>(output) { IsSuccess = true };
+                await writeSheetsAsync(workbookPart, sheets, styleMap);
+                workbookPart.Workbook.Save();
+            }, ct);
         }
         catch (Exception ex)
         {
@@ -98,33 +140,31 @@ public class ExcelExportService : IExcelExportService
     {
         try
         {
-            if (!output.CanSeek)
-                throw new ArgumentException("Stream must be seekable", nameof(output));
-
             var styleResponse = _styleProvider.BuildStylesheet(out var styleMap);
             if (!styleResponse.IsSuccess || styleResponse.Data is null)
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;
 
-            using var document = SpreadsheetDocument.Create(output, SpreadsheetDocumentType.Workbook, true);
-            var workbookPart = document.AddWorkbookPart();
-            workbookPart.Workbook = new Workbook();
-            var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-            stylesPart.Stylesheet = stylesheet;
-            var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
-
-            await writeWorksheetAsync(worksheetPart, styleMap);
-
-            var sheets = workbookPart.Workbook.AppendChild(new Sheets());
-            sheets.AppendChild(new Sheet
+            return await ExportUsingSeekableStreamAsync(output, async seekableStream =>
             {
-                Id = workbookPart.GetIdOfPart(worksheetPart),
-                SheetId = 1,
-                Name = options.SheetName
-            });
-            workbookPart.Workbook.Save();
-            await output.FlushAsync(ct);
-            return new ServiceResponse<Stream>(output) { IsSuccess = true };
+                using var document = SpreadsheetDocument.Create(seekableStream, SpreadsheetDocumentType.Workbook, true);
+                var workbookPart = document.AddWorkbookPart();
+                workbookPart.Workbook = new Workbook();
+                var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+                stylesPart.Stylesheet = stylesheet;
+                var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
+
+                await writeWorksheetAsync(worksheetPart, styleMap);
+
+                var sheets = workbookPart.Workbook.AppendChild(new Sheets());
+                sheets.AppendChild(new Sheet
+                {
+                    Id = workbookPart.GetIdOfPart(worksheetPart),
+                    SheetId = 1,
+                    Name = options.SheetName
+                });
+                workbookPart.Workbook.Save();
+            }, ct);
         }
         catch (Exception ex)
         {
@@ -273,60 +313,6 @@ public class ExcelExportService : IExcelExportService
         });
     }
 
-    private static async Task WriteRowsCoreAsync(OpenXmlWriter writer,
-        WriteRowsContext context,
-        Func<Task<bool>> moveNextAsync,
-        Func<IDataRecord?> current)
-    {
-        var (groupIndexValue, groupField) = GetGroupInfo(context.Columns);
-        object? currentGroup = null;
-        var written = 0;
-
-        while (await moveNextAsync())
-        {
-            context.CancellationToken.ThrowIfCancellationRequested();
-            if (written >= context.MaxRows)
-            {
-                if (context.EnforceLimit)
-                {
-                    throw new InvalidOperationException(
-                        $"Row limit exceeded ({ExcelExportLimits.MaxRowsPerSheet}). Enable splitting to export more rows.");
-                }
-                break;
-            }
-
-            var record = current() ?? throw new InvalidOperationException("Expected record instance.");
-            WriteRow(writer, record, context.Columns, context.StyleMap, groupField, groupIndexValue, ref currentGroup);
-            written++;
-        }
-    }
-
-    private readonly record struct WriteRowsContext(
-        IReadOnlyList<ColumnDefinition> Columns,
-        IReadOnlyDictionary<PredefinedStyle, uint> StyleMap,
-        int MaxRows,
-        bool EnforceLimit,
-        CancellationToken CancellationToken);
-
-    private static void WriteRow(OpenXmlWriter writer,
-        IDataRecord record,
-        IReadOnlyList<ColumnDefinition> columns,
-        IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
-        string? groupField,
-        int groupIndexValue,
-        ref object? currentGroup)
-    {
-        var dataRow = CreateDisconnectedRow(record, columns);
-        var isGroupRow = IsNewGroupRow(dataRow, groupField, currentGroup, out var newGroupValue);
-        if (isGroupRow)
-            currentGroup = newGroupValue;
-
-        var row = CreateRow(groupField is not null, isGroupRow);
-        writer.WriteStartElement(row);
-        WriteRowCells(writer, dataRow, columns, styleMap, groupField, groupIndexValue, isGroupRow);
-        writer.WriteEndElement();
-        ClearDataRow(dataRow);
-    }
 
     private static string ComposeSheetName(string sheetName, int sheetIndex)
     {
@@ -355,13 +341,103 @@ public class ExcelExportService : IExcelExportService
         return (groupInfo.i, columns[groupInfo.i].FieldName);
     }
 
-    private static bool IsNewGroupRow(DataRow dataRow, string? groupField, object? currentGroup, out object? newGroupValue)
+    private static async Task WriteRowsCoreAsync(OpenXmlWriter writer,
+        WriteRowsContext context,
+        Func<Task<bool>> moveNextAsync,
+        Func<IDataRecord?> current)
+    {
+        var (groupIndexValue, groupField) = GetGroupInfo(context.Columns);
+        object? currentGroup = null;
+        var written = 0;
+        int[]? ordinals = null;
+
+        while (await moveNextAsync())
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            if (written >= context.MaxRows)
+            {
+                if (context.EnforceLimit)
+                {
+                    throw new InvalidOperationException(
+                        $"Row limit exceeded ({ExcelExportLimits.MaxRowsPerSheet}). Enable splitting to export more rows.");
+                }
+                break;
+            }
+
+            var record = current() ?? throw new InvalidOperationException("Expected record instance.");
+            ordinals ??= BuildOrdinals(record, context.Columns);
+            WriteRow(writer, record, context.Columns, ordinals, context.StyleMap, groupField, groupIndexValue, ref currentGroup);
+            written++;
+        }
+    }
+
+    private readonly record struct WriteRowsContext(
+        IReadOnlyList<ColumnDefinition> Columns,
+        IReadOnlyDictionary<PredefinedStyle, uint> StyleMap,
+        int MaxRows,
+        bool EnforceLimit,
+        CancellationToken CancellationToken);
+
+    private static void WriteRow(OpenXmlWriter writer,
+        IDataRecord record,
+        IReadOnlyList<ColumnDefinition> columns,
+        IReadOnlyList<int> ordinals,
+        IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
+        string? groupField,
+        int groupIndexValue,
+        ref object? currentGroup)
+    {
+        var isGroupRow = IsNewGroupRow(record, ordinals, groupField, groupIndexValue, currentGroup, out var newGroupValue);
+        if (isGroupRow)
+            currentGroup = newGroupValue;
+
+        var row = CreateRow(groupField is not null, isGroupRow);
+        writer.WriteStartElement(row);
+        WriteRowCells(writer, record, columns, ordinals, styleMap, groupField, groupIndexValue, isGroupRow);
+        writer.WriteEndElement();
+    }
+
+    private static int[] BuildOrdinals(IDataRecord record, IReadOnlyList<ColumnDefinition> columns)
+    {
+        var ordinals = new int[columns.Count];
+        for (int i = 0; i < columns.Count; i++)
+        {
+            ordinals[i] = TryGetOrdinal(record, columns[i].FieldName);
+        }
+        return ordinals;
+    }
+
+    private static int TryGetOrdinal(IDataRecord record, string fieldName)
+    {
+        try
+        {
+            return record.GetOrdinal(fieldName);
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return -1;
+        }
+    }
+
+    private static object? GetRecordValue(IDataRecord record, int ordinal)
+    {
+        if (ordinal < 0 || record.IsDBNull(ordinal))
+            return null;
+        return record.GetValue(ordinal);
+    }
+
+    private static bool IsNewGroupRow(IDataRecord record,
+        IReadOnlyList<int> ordinals,
+        string? groupField,
+        int groupIndex,
+        object? currentGroup,
+        out object? newGroupValue)
     {
         newGroupValue = currentGroup;
-        if (groupField is null)
+        if (groupField is null || groupIndex < 0)
             return false;
 
-        var value = dataRow[groupField];
+        var value = GetRecordValue(record, ordinals[groupIndex]);
         if (Equals(value, currentGroup))
             return false;
 
@@ -378,8 +454,9 @@ public class ExcelExportService : IExcelExportService
     }
 
     private static void WriteRowCells(OpenXmlWriter writer,
-        DataRow dataRow,
+        IDataRecord record,
         IReadOnlyList<ColumnDefinition> columns,
+        IReadOnlyList<int> ordinals,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
         string? groupField,
         int groupIndexValue,
@@ -394,8 +471,8 @@ public class ExcelExportService : IExcelExportService
                 continue;
             }
 
-            var value = dataRow[col.FieldName];
-            if (value == DBNull.Value || value is null)
+            var value = GetRecordValue(record, ordinals[i]);
+            if (value is null)
             {
                 writer.WriteElement(new Cell());
                 continue;
@@ -404,41 +481,6 @@ public class ExcelExportService : IExcelExportService
             var cell = CreateCell(value, col, styleMap);
             writer.WriteElement(cell);
         }
-    }
-
-    private static DataRow CreateDisconnectedRow(IDataRecord record, IReadOnlyList<ColumnDefinition> columns)
-    {
-        var recordValues = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        for (int i = 0; i < record.FieldCount; i++)
-        {
-            recordValues[record.GetName(i)] = record.IsDBNull(i) ? DBNull.Value : record.GetValue(i);
-        }
-
-        var table = new DataTable();
-        foreach (var col in columns)
-        {
-            table.Columns.Add(col.FieldName, typeof(object));
-        }
-
-        var row = table.NewRow();
-        foreach (var col in columns)
-        {
-            if (recordValues.TryGetValue(col.FieldName, out var value))
-            {
-                row[col.FieldName] = value ?? DBNull.Value;
-            }
-            else
-            {
-                row[col.FieldName] = DBNull.Value;
-            }
-        }
-
-        return row;
-    }
-
-    private static void ClearDataRow(DataRow row)
-    {
-        row.Table?.Clear();
     }
 
     private static void WriteAutoFilter(OpenXmlWriter writer, ExcelExportOptions options, int columnCount)
@@ -471,11 +513,8 @@ public class ExcelExportService : IExcelExportService
                 cell.CellValue = new CellValue((bool)value ? "1" : "0");
                 break;
             default:
-                cell.DataType = CellValues.InlineString;
-                var s = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
-                var inline = new InlineString();
-                inline.AppendChild(new Text(s));
-                cell.InlineString = inline;
+                cell.DataType = CellValues.String;
+                cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
                 break;
         }
         return cell;

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -163,7 +163,7 @@ public class ExcelExportService : IExcelExportService
                 {
                     Id = workbookPart.GetIdOfPart(worksheetPart),
                     SheetId = 1,
-                    Name = options.SheetName
+                    Name = ComposeSheetName(options.SheetName, 1)
                 });
                 workbookPart.Workbook.Save();
             }, ct);

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -12,7 +12,6 @@ namespace DataToExcel.Services;
 
 public class ExcelExportService : IExcelExportService
 {
-    private const int GarbageCollectionRowInterval = 50_000;
     private readonly IExcelStyleProvider _styleProvider;
     public ExcelExportService(IExcelStyleProvider styleProvider)
         => _styleProvider = styleProvider;
@@ -76,7 +75,6 @@ public class ExcelExportService : IExcelExportService
                 seekableStream.Position = 0;
                 await seekableStream.CopyToAsync(output, 81920, ct);
                 await output.FlushAsync(ct);
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, blocking: false, compacting: false);
             }
             else
             {
@@ -89,10 +87,7 @@ public class ExcelExportService : IExcelExportService
         {
             if (needsStaging)
             {
-                var tempName = (seekableStream as FileStream)?.Name;
                 await seekableStream.DisposeAsync();
-                if (!string.IsNullOrWhiteSpace(tempName) && File.Exists(tempName))
-                    File.Delete(tempName);
             }
         }
     }
@@ -350,6 +345,7 @@ public class ExcelExportService : IExcelExportService
     {
         var (groupIndexValue, groupField) = GetGroupInfo(context.Columns);
         object? currentGroup = null;
+        var hasCurrentGroup = false;
         var written = 0;
         int[]? ordinals = null;
 
@@ -368,13 +364,9 @@ public class ExcelExportService : IExcelExportService
 
             var record = current() ?? throw new InvalidOperationException("Expected record instance.");
             ordinals ??= BuildOrdinals(record, context.Columns);
-            WriteRow(writer, record, context.Columns, ordinals, context.StyleMap, groupField, groupIndexValue, ref currentGroup);
+            WriteRow(writer, record, context.Columns, ordinals, context.StyleMap, groupField, groupIndexValue,
+                ref currentGroup, ref hasCurrentGroup);
             written++;
-
-            if (written % GarbageCollectionRowInterval == 0)
-            {
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, blocking: false, compacting: false);
-            }
         }
     }
 
@@ -392,11 +384,16 @@ public class ExcelExportService : IExcelExportService
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
         string? groupField,
         int groupIndexValue,
-        ref object? currentGroup)
+        ref object? currentGroup,
+        ref bool hasCurrentGroup)
     {
-        var isGroupRow = IsNewGroupRow(record, ordinals, groupField, groupIndexValue, currentGroup, out var newGroupValue);
+        var isGroupRow = IsNewGroupRow(record, ordinals, groupField, groupIndexValue, currentGroup, hasCurrentGroup,
+            out var newGroupValue);
         if (isGroupRow)
+        {
             currentGroup = newGroupValue;
+            hasCurrentGroup = true;
+        }
 
         var row = CreateRow(groupField is not null, isGroupRow);
         writer.WriteStartElement(row);
@@ -453,6 +450,7 @@ public class ExcelExportService : IExcelExportService
         string? groupField,
         int groupIndex,
         object? currentGroup,
+        bool hasCurrentGroup,
         out object? newGroupValue)
     {
         newGroupValue = currentGroup;
@@ -460,7 +458,7 @@ public class ExcelExportService : IExcelExportService
             return false;
 
         var value = GetRecordValue(record, ordinals[groupIndex]);
-        if (Equals(value, currentGroup))
+        if (hasCurrentGroup && Equals(value, currentGroup))
             return false;
 
         newGroupValue = value;

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -12,6 +12,7 @@ namespace DataToExcel.Services;
 
 public class ExcelExportService : IExcelExportService
 {
+    private const int GarbageCollectionRowInterval = 50_000;
     private readonly IExcelStyleProvider _styleProvider;
     public ExcelExportService(IExcelStyleProvider styleProvider)
         => _styleProvider = styleProvider;
@@ -75,6 +76,7 @@ public class ExcelExportService : IExcelExportService
                 seekableStream.Position = 0;
                 await seekableStream.CopyToAsync(output, 81920, ct);
                 await output.FlushAsync(ct);
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, blocking: false, compacting: false);
             }
             else
             {
@@ -368,6 +370,11 @@ public class ExcelExportService : IExcelExportService
             ordinals ??= BuildOrdinals(record, context.Columns);
             WriteRow(writer, record, context.Columns, ordinals, context.StyleMap, groupField, groupIndexValue, ref currentGroup);
             written++;
+
+            if (written % GarbageCollectionRowInterval == 0)
+            {
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, blocking: false, compacting: false);
+            }
         }
     }
 

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -1,6 +1,8 @@
 using System.Data;
 using System.Globalization;
+using System.IO.Compression;
 using System.Text;
+using System.Xml;
 using DataToExcel.Models;
 using DataToExcel.Services.Interfaces;
 using DataToExcel.Utilities;
@@ -30,8 +32,8 @@ public class ExcelExportService : IExcelExportService
         CancellationToken ct = default)
         => options.SplitIntoMultipleSheets
             ? ExportMultipleSheetsAsync(data, columns, output, options, ct)
-            : ExportAsyncCore(output, options, (worksheetPart, styleMap)
-            => WriteWorksheetAsync(worksheetPart, columns, options, styleMap,
+            : ExportAsyncCore(output, options, (worksheetStream, styleMap)
+            => WriteWorksheetXmlAsync(worksheetStream, columns, options, styleMap,
                 writer => WriteRows(writer, data, columns, styleMap, ExcelExportLimits.MaxDataRowsPerSheet, ct)), ct);
 
     private Task<ServiceResponse<Stream>> ExportMultipleSheetsAsync(IAsyncEnumerable<IDataRecord> data,
@@ -132,7 +134,7 @@ public class ExcelExportService : IExcelExportService
 
     private async Task<ServiceResponse<Stream>> ExportAsyncCore(Stream output,
         ExcelExportOptions options,
-        Func<WorksheetPart, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeWorksheetAsync,
+        Func<Stream, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeWorksheetAsync,
         CancellationToken ct)
     {
         try
@@ -142,26 +144,8 @@ public class ExcelExportService : IExcelExportService
                 return new ServiceResponse<Stream> { IsSuccess = false, ErrorMessage = styleResponse.ErrorMessage };
             var stylesheet = styleResponse.Data;
 
-            return await ExportUsingSeekableStreamAsync(output, async seekableStream =>
-            {
-                using var document = SpreadsheetDocument.Create(seekableStream, SpreadsheetDocumentType.Workbook, true);
-                var workbookPart = document.AddWorkbookPart();
-                workbookPart.Workbook = new Workbook();
-                var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-                stylesPart.Stylesheet = stylesheet;
-                var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
-
-                await writeWorksheetAsync(worksheetPart, styleMap);
-
-                var sheets = workbookPart.Workbook.AppendChild(new Sheets());
-                sheets.AppendChild(new Sheet
-                {
-                    Id = workbookPart.GetIdOfPart(worksheetPart),
-                    SheetId = 1,
-                    Name = ComposeSheetName(options.SheetName, 1)
-                });
-                workbookPart.Workbook.Save();
-            }, ct);
+            await ExportSingleSheetPackageAsync(output, options, stylesheet, styleMap, writeWorksheetAsync, ct);
+            return new ServiceResponse<Stream>(output) { IsSuccess = true };
         }
         catch (Exception ex)
         {
@@ -169,102 +153,253 @@ public class ExcelExportService : IExcelExportService
         }
     }
 
+    private static async Task ExportSingleSheetPackageAsync(Stream output,
+        ExcelExportOptions options,
+        Stylesheet stylesheet,
+        IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
+        Func<Stream, IReadOnlyDictionary<PredefinedStyle, uint>, Task> writeWorksheetAsync,
+        CancellationToken ct)
+    {
+        using var archive = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true);
+
+        await WriteContentTypesAsync(archive, ct);
+        await WriteRootRelationshipsAsync(archive, ct);
+        await WriteWorkbookAsync(archive, ComposeSheetName(options.SheetName, 1), ct);
+        await WriteWorkbookRelationshipsAsync(archive, ct);
+        await WriteStylesAsync(archive, stylesheet, ct);
+
+        var worksheetEntry = archive.CreateEntry("xl/worksheets/sheet1.xml", CompressionLevel.Fastest);
+        await using var worksheetStream = worksheetEntry.Open();
+        await writeWorksheetAsync(worksheetStream, styleMap);
+
+        await output.FlushAsync(ct);
+    }
+
+    private static async Task WriteContentTypesAsync(ZipArchive archive, CancellationToken ct)
+    {
+        var entry = archive.CreateEntry("[Content_Types].xml", CompressionLevel.Fastest);
+        await using var stream = entry.Open();
+        await using var writer = CreatePackageXmlWriter(stream);
+
+        await writer.WriteStartDocumentAsync();
+        await writer.WriteStartElementAsync(null, "Types", "http://schemas.openxmlformats.org/package/2006/content-types");
+        await WriteDefaultContentTypeAsync(writer, "rels", "application/vnd.openxmlformats-package.relationships+xml");
+        await WriteDefaultContentTypeAsync(writer, "xml", "application/xml");
+        await WriteOverrideContentTypeAsync(writer, "/xl/workbook.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml");
+        await WriteOverrideContentTypeAsync(writer, "/xl/worksheets/sheet1.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
+        await WriteOverrideContentTypeAsync(writer, "/xl/styles.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml");
+        await writer.WriteEndElementAsync();
+        await writer.WriteEndDocumentAsync();
+        await writer.FlushAsync();
+        ct.ThrowIfCancellationRequested();
+    }
+
+    private static async Task WriteRootRelationshipsAsync(ZipArchive archive, CancellationToken ct)
+    {
+        var entry = archive.CreateEntry("_rels/.rels", CompressionLevel.Fastest);
+        await using var stream = entry.Open();
+        await using var writer = CreatePackageXmlWriter(stream);
+
+        await writer.WriteStartDocumentAsync();
+        await writer.WriteStartElementAsync(null, "Relationships", "http://schemas.openxmlformats.org/package/2006/relationships");
+        await WriteRelationshipAsync(writer, "rId1",
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+            "xl/workbook.xml");
+        await writer.WriteEndElementAsync();
+        await writer.WriteEndDocumentAsync();
+        await writer.FlushAsync();
+        ct.ThrowIfCancellationRequested();
+    }
+
+    private static async Task WriteWorkbookAsync(ZipArchive archive, string sheetName, CancellationToken ct)
+    {
+        var entry = archive.CreateEntry("xl/workbook.xml", CompressionLevel.Fastest);
+        await using var stream = entry.Open();
+        await using var writer = CreatePackageXmlWriter(stream);
+
+        await writer.WriteStartDocumentAsync();
+        await writer.WriteStartElementAsync(null, "workbook", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        await writer.WriteAttributeStringAsync("xmlns", "r", null, "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        await writer.WriteStartElementAsync(null, "sheets", null);
+        await writer.WriteStartElementAsync(null, "sheet", null);
+        await writer.WriteAttributeStringAsync(null, "name", null, sheetName);
+        await writer.WriteAttributeStringAsync(null, "sheetId", null, "1");
+        await writer.WriteAttributeStringAsync("r", "id", null, "rId1");
+        await writer.WriteEndElementAsync(); // sheet
+        await writer.WriteEndElementAsync(); // sheets
+        await writer.WriteEndElementAsync(); // workbook
+        await writer.WriteEndDocumentAsync();
+        await writer.FlushAsync();
+        ct.ThrowIfCancellationRequested();
+    }
+
+    private static async Task WriteWorkbookRelationshipsAsync(ZipArchive archive, CancellationToken ct)
+    {
+        var entry = archive.CreateEntry("xl/_rels/workbook.xml.rels", CompressionLevel.Fastest);
+        await using var stream = entry.Open();
+        await using var writer = CreatePackageXmlWriter(stream);
+
+        await writer.WriteStartDocumentAsync();
+        await writer.WriteStartElementAsync(null, "Relationships", "http://schemas.openxmlformats.org/package/2006/relationships");
+        await WriteRelationshipAsync(writer, "rId1",
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet",
+            "worksheets/sheet1.xml");
+        await WriteRelationshipAsync(writer, "rId2",
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+            "styles.xml");
+        await writer.WriteEndElementAsync();
+        await writer.WriteEndDocumentAsync();
+        await writer.FlushAsync();
+        ct.ThrowIfCancellationRequested();
+    }
+
+    private static async Task WriteStylesAsync(ZipArchive archive, Stylesheet stylesheet, CancellationToken ct)
+    {
+        var entry = archive.CreateEntry("xl/styles.xml", CompressionLevel.Fastest);
+        await using var stream = entry.Open();
+        stylesheet.Save(stream);
+        ct.ThrowIfCancellationRequested();
+    }
+
+    private static XmlWriter CreatePackageXmlWriter(Stream stream)
+        => XmlWriter.Create(stream, new XmlWriterSettings
+        {
+            Async = true,
+            Encoding = Encoding.UTF8,
+            CloseOutput = false
+        });
+
+    private static async Task WriteDefaultContentTypeAsync(XmlWriter writer, string extension, string contentType)
+    {
+        await writer.WriteStartElementAsync(null, "Default", null);
+        await writer.WriteAttributeStringAsync(null, "Extension", null, extension);
+        await writer.WriteAttributeStringAsync(null, "ContentType", null, contentType);
+        await writer.WriteEndElementAsync();
+    }
+
+    private static async Task WriteOverrideContentTypeAsync(XmlWriter writer, string partName, string contentType)
+    {
+        await writer.WriteStartElementAsync(null, "Override", null);
+        await writer.WriteAttributeStringAsync(null, "PartName", null, partName);
+        await writer.WriteAttributeStringAsync(null, "ContentType", null, contentType);
+        await writer.WriteEndElementAsync();
+    }
+
+    private static async Task WriteRelationshipAsync(XmlWriter writer, string id, string type, string target)
+    {
+        await writer.WriteStartElementAsync(null, "Relationship", null);
+        await writer.WriteAttributeStringAsync(null, "Id", null, id);
+        await writer.WriteAttributeStringAsync(null, "Type", null, type);
+        await writer.WriteAttributeStringAsync(null, "Target", null, target);
+        await writer.WriteEndElementAsync();
+    }
+
     private static async Task WriteWorksheetAsync(WorksheetPart worksheetPart,
         IReadOnlyList<ColumnDefinition> columns,
         ExcelExportOptions options,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
-        Func<OpenXmlWriter, Task> writeRowsAsync)
+        Func<XmlWriter, Task> writeRowsAsync)
     {
-        using var writer = OpenXmlWriter.Create(worksheetPart);
-        writer.WriteStartElement(new Worksheet());
+        await using var stream = worksheetPart.GetStream(FileMode.Create, FileAccess.Write);
+        await WriteWorksheetXmlAsync(stream, columns, options, styleMap, writeRowsAsync);
+    }
+
+    private static async Task WriteWorksheetXmlAsync(Stream stream,
+        IReadOnlyList<ColumnDefinition> columns,
+        ExcelExportOptions options,
+        IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
+        Func<XmlWriter, Task> writeRowsAsync)
+    {
+        await using var writer = XmlWriter.Create(stream, new XmlWriterSettings
+        {
+            Async = true,
+            Encoding = Encoding.UTF8,
+            CloseOutput = false
+        });
+        await writer.WriteStartDocumentAsync();
+        await writer.WriteStartElementAsync(null, "worksheet", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
 
         WriteSheetViews(writer, options);
         WriteColumns(writer, columns);
         WriteSheetFormatProperties(writer, columns);
 
-        writer.WriteStartElement(new SheetData());
+        writer.WriteStartElement("sheetData");
         WriteHeader(writer, columns, styleMap);
         await writeRowsAsync(writer);
-        writer.WriteEndElement(); // SheetData
+        writer.WriteEndElement(); // sheetData
 
         WriteAutoFilter(writer, options, columns.Count);
 
-        writer.WriteEndElement(); // Worksheet
-        writer.Close();
+        writer.WriteEndElement(); // worksheet
+        await writer.WriteEndDocumentAsync();
+        await writer.FlushAsync();
     }
 
-    private static void WriteSheetViews(OpenXmlWriter writer, ExcelExportOptions options)
+    private static void WriteSheetViews(XmlWriter writer, ExcelExportOptions options)
     {
         if (!options.FreezeHeader) return;
-        writer.WriteStartElement(new SheetViews());
-        writer.WriteElement(new SheetView
-        {
-            WorkbookViewId = 0,
-            Pane = new Pane
-            {
-                VerticalSplit = 1,
-                TopLeftCell = "A2",
-                ActivePane = PaneValues.BottomLeft,
-                State = PaneStateValues.Frozen
-            }
-        });
-        writer.WriteEndElement(); // SheetViews
+        writer.WriteStartElement("sheetViews");
+        writer.WriteStartElement("sheetView");
+        writer.WriteAttributeString("workbookViewId", "0");
+        writer.WriteStartElement("pane");
+        writer.WriteAttributeString("ySplit", "1");
+        writer.WriteAttributeString("topLeftCell", "A2");
+        writer.WriteAttributeString("activePane", "bottomLeft");
+        writer.WriteAttributeString("state", "frozen");
+        writer.WriteEndElement(); // pane
+        writer.WriteEndElement(); // sheetView
+        writer.WriteEndElement(); // sheetViews
     }
 
-    private static void WriteSheetFormatProperties(OpenXmlWriter writer, IReadOnlyList<ColumnDefinition> columns)
+    private static void WriteSheetFormatProperties(XmlWriter writer, IReadOnlyList<ColumnDefinition> columns)
     {
         if (!columns.Any(c => c.Group)) return;
-        writer.WriteElement(new SheetFormatProperties { OutlineLevelRow = 1 });
+        writer.WriteStartElement("sheetFormatPr");
+        writer.WriteAttributeString("outlineLevelRow", "1");
+        writer.WriteEndElement();
     }
 
-    private static void WriteColumns(OpenXmlWriter writer, IReadOnlyList<ColumnDefinition> columns)
+    private static void WriteColumns(XmlWriter writer, IReadOnlyList<ColumnDefinition> columns)
     {
         if (!columns.Any(c => c.Width.HasValue || c.Hidden)) return;
-        writer.WriteStartElement(new Columns());
+        writer.WriteStartElement("cols");
         uint i = 1;
         foreach (var col in columns)
         {
             if (col.Width.HasValue || col.Hidden)
             {
-                var column = new Column
-                {
-                    Min = i,
-                    Max = i
-                };
+                writer.WriteStartElement("col");
+                writer.WriteAttributeString("min", i.ToString(CultureInfo.InvariantCulture));
+                writer.WriteAttributeString("max", i.ToString(CultureInfo.InvariantCulture));
                 if (col.Hidden)
                 {
-                    column.Hidden = true;
+                    writer.WriteAttributeString("hidden", "1");
                 }
                 if (col.Width.HasValue)
                 {
-                    column.Width = col.Width.Value;
-                    column.CustomWidth = true;
+                    writer.WriteAttributeString("width", col.Width.Value.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteAttributeString("customWidth", "1");
                 }
-                writer.WriteElement(column);
+                writer.WriteEndElement();
             }
             i++;
         }
-        writer.WriteEndElement(); // Columns
+        writer.WriteEndElement(); // cols
     }
 
-    private static void WriteHeader(OpenXmlWriter writer,
+    private static void WriteHeader(XmlWriter writer,
         IReadOnlyList<ColumnDefinition> columns,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap)
     {
-        writer.WriteStartElement(new Row());
+        writer.WriteStartElement("row");
         foreach (var col in columns)
         {
-            writer.WriteElement(new Cell
-            {
-                DataType = CellValues.String,
-                CellValue = new CellValue(col.Title ?? string.Empty),
-                StyleIndex = styleMap[PredefinedStyle.Header]
-            });
+            WriteCell(writer, col.Title ?? string.Empty, CellValues.String, styleMap[PredefinedStyle.Header]);
         }
-        writer.WriteEndElement(); // Row
+        writer.WriteEndElement(); // row
     }
 
-    private static async Task WriteRows(OpenXmlWriter writer,
+    private static async Task WriteRows(XmlWriter writer,
         IAsyncEnumerable<IDataRecord> data,
         IReadOnlyList<ColumnDefinition> columns,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
@@ -278,7 +413,7 @@ public class ExcelExportService : IExcelExportService
             current: () => enumerator.Current);
     }
 
-    private static async Task WriteRows(OpenXmlWriter writer,
+    private static async Task WriteRows(XmlWriter writer,
         BufferedAsyncRecordEnumerator data,
         IReadOnlyList<ColumnDefinition> columns,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
@@ -297,7 +432,7 @@ public class ExcelExportService : IExcelExportService
         IReadOnlyList<ColumnDefinition> columns,
         ExcelExportOptions options,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
-        Func<OpenXmlWriter, Task> writeRowsAsync)
+        Func<XmlWriter, Task> writeRowsAsync)
     {
         var worksheetPart = workbookPart.AddNewPart<WorksheetPart>();
         await WriteWorksheetAsync(worksheetPart, columns, options, styleMap, writeRowsAsync);
@@ -338,7 +473,7 @@ public class ExcelExportService : IExcelExportService
         return (groupInfo.i, columns[groupInfo.i].FieldName);
     }
 
-    private static async Task WriteRowsCoreAsync(OpenXmlWriter writer,
+    private static async Task WriteRowsCoreAsync(XmlWriter writer,
         WriteRowsContext context,
         Func<Task<bool>> moveNextAsync,
         Func<IDataRecord?> current)
@@ -364,8 +499,16 @@ public class ExcelExportService : IExcelExportService
 
             var record = current() ?? throw new InvalidOperationException("Expected record instance.");
             ordinals ??= BuildOrdinals(record, context.Columns);
+            var isGroupRow = IsNewGroupRow(record, ordinals, groupField, groupIndexValue, currentGroup,
+                hasCurrentGroup, out var newGroupValue);
+            if (isGroupRow)
+            {
+                currentGroup = newGroupValue;
+                hasCurrentGroup = true;
+            }
+
             WriteRow(writer, record, context.Columns, ordinals, context.StyleMap, groupField, groupIndexValue,
-                ref currentGroup, ref hasCurrentGroup);
+                isGroupRow);
             written++;
         }
     }
@@ -377,26 +520,16 @@ public class ExcelExportService : IExcelExportService
         bool EnforceLimit,
         CancellationToken CancellationToken);
 
-    private static void WriteRow(OpenXmlWriter writer,
+    private static void WriteRow(XmlWriter writer,
         IDataRecord record,
         IReadOnlyList<ColumnDefinition> columns,
         IReadOnlyList<int> ordinals,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap,
         string? groupField,
         int groupIndexValue,
-        ref object? currentGroup,
-        ref bool hasCurrentGroup)
+        bool isGroupRow)
     {
-        var isGroupRow = IsNewGroupRow(record, ordinals, groupField, groupIndexValue, currentGroup, hasCurrentGroup,
-            out var newGroupValue);
-        if (isGroupRow)
-        {
-            currentGroup = newGroupValue;
-            hasCurrentGroup = true;
-        }
-
-        var row = CreateRow(groupField is not null, isGroupRow);
-        writer.WriteStartElement(row);
+        WriteRowStart(writer, groupField is not null, isGroupRow);
         WriteRowCells(writer, record, columns, ordinals, styleMap, groupField, groupIndexValue, isGroupRow);
         writer.WriteEndElement();
     }
@@ -465,15 +598,14 @@ public class ExcelExportService : IExcelExportService
         return true;
     }
 
-    private static Row CreateRow(bool hasGroup, bool isGroupRow)
+    private static void WriteRowStart(XmlWriter writer, bool hasGroup, bool isGroupRow)
     {
-        var row = new Row();
+        writer.WriteStartElement("row");
         if (hasGroup && !isGroupRow)
-            row.OutlineLevel = 1;
-        return row;
+            writer.WriteAttributeString("outlineLevel", "1");
     }
 
-    private static void WriteRowCells(OpenXmlWriter writer,
+    private static void WriteRowCells(XmlWriter writer,
         IDataRecord record,
         IReadOnlyList<ColumnDefinition> columns,
         IReadOnlyList<int> ordinals,
@@ -487,57 +619,117 @@ public class ExcelExportService : IExcelExportService
             var col = columns[i];
             if (groupField is not null && i == groupIndexValue && !isGroupRow)
             {
-                writer.WriteElement(new Cell());
+                WriteBlankCell(writer);
                 continue;
             }
 
-            var value = GetRecordValue(record, ordinals[i]);
-            if (value is null)
+            var ordinal = ordinals[i];
+            if (ordinal < 0 || record.IsDBNull(ordinal))
             {
-                writer.WriteElement(new Cell());
+                WriteBlankCell(writer);
                 continue;
             }
 
-            var cell = CreateCell(value, col, styleMap);
-            writer.WriteElement(cell);
+            WriteCell(writer, record, ordinal, col, styleMap);
         }
     }
 
-    private static void WriteAutoFilter(OpenXmlWriter writer, ExcelExportOptions options, int columnCount)
+    private static void WriteAutoFilter(XmlWriter writer, ExcelExportOptions options, int columnCount)
     {
         if (!options.AutoFilter) return;
         var endCol = GetColumnName(columnCount);
-        writer.WriteElement(new AutoFilter { Reference = $"A1:{endCol}1" });
+        writer.WriteStartElement("autoFilter");
+        writer.WriteAttributeString("ref", $"A1:{endCol}1");
+        writer.WriteEndElement();
     }
 
-    private static Cell CreateCell(object value, ColumnDefinition col,
+    private static void WriteCell(XmlWriter writer, IDataRecord record, int ordinal, ColumnDefinition col,
         IReadOnlyDictionary<PredefinedStyle, uint> styleMap)
     {
         var style = col.Style ?? GetStyleFromDataType(col.DataType);
-        var cell = new Cell { StyleIndex = styleMap[style] };
         switch (col.DataType)
         {
             case ColumnDataType.Number:
             case ColumnDataType.Currency:
             case ColumnDataType.Percentage:
-                cell.DataType = CellValues.Number;
-                cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
+                WriteNumberCell(writer, record, ordinal, styleMap[style]);
                 break;
             case ColumnDataType.DateTime:
-                cell.DataType = CellValues.Number;
-                var dt = Convert.ToDateTime(value, CultureInfo.InvariantCulture);
-                cell.CellValue = new CellValue(dt.ToOADate().ToString(CultureInfo.InvariantCulture));
+                WriteDateTimeCell(writer, record, ordinal, styleMap[style]);
                 break;
             case ColumnDataType.Boolean:
-                cell.DataType = CellValues.Boolean;
-                cell.CellValue = new CellValue((bool)value ? "1" : "0");
+                WriteCell(writer, GetBooleanCellValue(record, ordinal), CellValues.Boolean, styleMap[style]);
                 break;
             default:
-                cell.DataType = CellValues.String;
-                cell.CellValue = new CellValue(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty);
+                WriteCell(writer, GetStringCellValue(record, ordinal), CellValues.String, styleMap[style]);
                 break;
         }
-        return cell;
+    }
+
+    private static void WriteNumberCell(XmlWriter writer, IDataRecord record, int ordinal, uint styleIndex)
+    {
+        writer.WriteStartElement("c");
+        writer.WriteAttributeString("s", styleIndex.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("t", "n");
+        writer.WriteStartElement("v");
+
+        var fieldType = record.GetFieldType(ordinal);
+        if (fieldType == typeof(int))
+            writer.WriteValue(record.GetInt32(ordinal));
+        else if (fieldType == typeof(long))
+            writer.WriteValue(record.GetInt64(ordinal));
+        else if (fieldType == typeof(short))
+            writer.WriteValue(record.GetInt16(ordinal));
+        else if (fieldType == typeof(decimal))
+            writer.WriteValue(record.GetDecimal(ordinal));
+        else if (fieldType == typeof(double))
+            writer.WriteValue(record.GetDouble(ordinal));
+        else if (fieldType == typeof(float))
+            writer.WriteValue(record.GetFloat(ordinal));
+        else
+            writer.WriteString(Convert.ToString(record.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty);
+
+        writer.WriteEndElement(); // v
+        writer.WriteEndElement(); // c
+    }
+
+    private static void WriteDateTimeCell(XmlWriter writer, IDataRecord record, int ordinal, uint styleIndex)
+    {
+        var value = record.GetFieldType(ordinal) == typeof(DateTime)
+            ? record.GetDateTime(ordinal)
+            : Convert.ToDateTime(record.GetValue(ordinal), CultureInfo.InvariantCulture);
+        WriteCell(writer, value.ToOADate().ToString(CultureInfo.InvariantCulture), CellValues.Number, styleIndex);
+    }
+
+    private static string GetBooleanCellValue(IDataRecord record, int ordinal)
+    {
+        if (record.GetFieldType(ordinal) == typeof(bool))
+            return record.GetBoolean(ordinal) ? "1" : "0";
+        return Convert.ToBoolean(record.GetValue(ordinal), CultureInfo.InvariantCulture) ? "1" : "0";
+    }
+
+    private static string GetStringCellValue(IDataRecord record, int ordinal)
+    {
+        if (record.GetFieldType(ordinal) == typeof(string))
+            return record.GetString(ordinal);
+        return Convert.ToString(record.GetValue(ordinal), CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+
+    private static void WriteCell(XmlWriter writer, string value, CellValues dataType, uint styleIndex)
+    {
+        writer.WriteStartElement("c");
+        writer.WriteAttributeString("s", styleIndex.ToString(CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("t", GetCellDataTypeValue(dataType));
+        writer.WriteStartElement("v");
+        writer.WriteString(value);
+        writer.WriteEndElement(); // v
+        writer.WriteEndElement(); // c
+    }
+
+    private static void WriteBlankCell(XmlWriter writer)
+    {
+        writer.WriteStartElement("c");
+        writer.WriteEndElement();
     }
 
     private static PredefinedStyle GetStyleFromDataType(ColumnDataType type) => type switch
@@ -549,6 +741,15 @@ public class ExcelExportService : IExcelExportService
         ColumnDataType.Percentage => PredefinedStyle.Percentage,
         _ => PredefinedStyle.Text
     };
+
+    private static string GetCellDataTypeValue(CellValues dataType)
+    {
+        if (dataType == CellValues.Number)
+            return "n";
+        if (dataType == CellValues.Boolean)
+            return "b";
+        return "str";
+    }
 
     private static string GetColumnName(int index)
     {

--- a/DataToExcel/Services/ExcelExportService.cs
+++ b/DataToExcel/Services/ExcelExportService.cs
@@ -406,16 +406,31 @@ public class ExcelExportService : IExcelExportService
 
     private static int[] BuildOrdinals(IDataRecord record, IReadOnlyList<ColumnDefinition> columns)
     {
+        var ordinalsByName = BuildOrdinalMap(record);
         var ordinals = new int[columns.Count];
         for (int i = 0; i < columns.Count; i++)
         {
-            ordinals[i] = TryGetOrdinal(record, columns[i].FieldName);
+            ordinals[i] = TryGetOrdinal(record, ordinalsByName, columns[i].FieldName);
         }
         return ordinals;
     }
 
-    private static int TryGetOrdinal(IDataRecord record, string fieldName)
+    private static Dictionary<string, int> BuildOrdinalMap(IDataRecord record)
     {
+        var map = new Dictionary<string, int>(record.FieldCount, StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < record.FieldCount; i++)
+        {
+            map[record.GetName(i)] = i;
+        }
+
+        return map;
+    }
+
+    private static int TryGetOrdinal(IDataRecord record, IReadOnlyDictionary<string, int> ordinalsByName, string fieldName)
+    {
+        if (ordinalsByName.TryGetValue(fieldName, out var ordinal))
+            return ordinal;
+
         try
         {
             return record.GetOrdinal(fieldName);


### PR DESCRIPTION
### Motivation
- Remove the requirement that output `Stream` instances be seekable so exports can write to non-seekable targets by staging to a temporary file when needed.
- Improve performance and memory usage by avoiding intermediate `DataRow` creation and reading values directly from `IDataRecord` using cached ordinals.
- Ensure generated sheet names respect Excel limits and append stable suffixes for multi-sheet exports.
- Simplify cell text handling to use `CellValues.String`/`CellValue` for inline string content.

### Description
- Added `ExportUsingSeekableStreamAsync` and `CreateTempFileStream` to transparently stage to a temporary seekable file when `output.CanSeek` is false and to copy back to the original stream afterwards.
- Reworked `ExportMultipleSheetsAsyncCore` and `ExportAsyncCore` to use the new staging helper and removed the prior upfront `Stream` seekability check.
- Replaced `DataRow`-based row construction with direct `IDataRecord` access and introduced `BuildOrdinals`, `TryGetOrdinal`, and `GetRecordValue` to cache and use field ordinals for each record.
- Updated grouping logic to use ordinals and `IDataRecord` values, and changed `WriteRowsCoreAsync` to compute ordinals once per record set.
- Removed `CreateDisconnectedRow` and `ClearDataRow` and adjusted `WriteRow`, `WriteRowCells`, and related helpers to accept `IDataRecord` plus ordinals.
- Implemented `ComposeSheetName` and `TrimSheetName` to cap sheet names at Excel's 31-character limit and add numeric suffixes for additional sheets.
- Changed cell string handling from `InlineString` to `CellValues.String` with `CellValue` for string/text types.

### Testing
- Ran the existing automated unit test suite and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe782164488320b13fa93c45cadbd8)